### PR TITLE
Armor Damage Thresholds

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -280,6 +280,8 @@
 			how_cool_are_your_threads += "Adding or removing items from [src] makes no noise.\n"
 		how_cool_are_your_threads += "</span>"
 		. += how_cool_are_your_threads.Join()
+	if(damage_threshold && damage_threshold > 0)
+		. += "It has a Damage Treshold of: [damage_threshold]"
 
 	if(LAZYLEN(armor_list))
 		armor_list.Cut()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1,3 +1,18 @@
+// Damage Threshold defined here as it seems to be the best place.
+#define DT_BASIC "5"
+#define DT_STRONG "10"
+#define DT_ADVANCED "15"
+#define DT_MAX "20"
+// General DT Rules
+// Basic: Generically applied to heavy armor.
+// Strong: Applied to higher tier heavy armor such as faction armor and some salvaged power armor.
+// Advanced: Applied mainly to either advanced armor or specialty armor found as dungeon rewards.
+// Max: Full fledged power armor.
+// DT does not make you immune to damage and falls off the greater the damage is (I.E. it works better against low damage attacks)
+// Higher damage hits and armor penetrating hits from heavy hitters will still make DT a minor benefit, noticable but not extreme.
+// NOTE when editing DT for balance, change the above values, it will effect every item assigned this define so easy adjustment. -Possum
+
+
 /obj/item/clothing/suit/armor
 	allowed = null
 	cold_protection = CHEST|GROIN
@@ -405,7 +420,7 @@ Suits. 0-10 in its primary value, slowdown 0, various utility
 	allowed = list(/obj/item/melee/onehanded, /obj/item/twohanded, /obj/item/melee/smith, /obj/item/melee/smith/twohand, /obj/item/shield)
 
 
-// Heavy armor. 50-65 in its primary value, slowdown 0.15
+// Heavy armor. 50-65 in its primary value, slowdown 0.15, damage threshold 5
 /obj/item/clothing/suit/armored/heavy
 	name = "heavy armor template"
 	icon = 'icons/fallout/clothing/armored_heavy.dmi'
@@ -413,6 +428,7 @@ Suits. 0-10 in its primary value, slowdown 0, various utility
 	slowdown = 0.15
 	allowed = list(/obj/item/gun, /obj/item/melee/onehanded, /obj/item/twohanded, /obj/item/melee/smith, /obj/item/melee/smith/twohand, /obj/item/shield)
 	strip_delay = 50
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armored/heavy/legion
 	slowdown = 0.1

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -1257,6 +1257,10 @@
 	// Slowdown = 0.15 | Heavy armor standard
 	mutantrace_variation = STYLE_DIGITIGRADE
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	damage_threshold = DT_STRONG
+	// Originally I was going to do quality + 2 at the crafting step but due to some weirdness and laziness I just hacked it here.
+	// Stats are affected by quality and if you're making heavy armor you're making masterwork and plating it. So this fits.
+	// Plus, unlike other heavy armor you either start with or clear a dungeon for, this *always* requires work to get.
 
 /obj/item/clothing/suit/armored/heavy/smith_armor_heavy/Initialize(mapload) // TO GO EVEN FURTHER BYOND!!!
 	. = ..()

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -115,6 +115,7 @@
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 50, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 0, "wound" = 20)
 	slowdown = 0.16
 	strip_delay = 10
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armor/f13/metalarmor/laserproof
 	name = "polished metal armor"
@@ -165,6 +166,7 @@
 	slowdown = 0.12
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 5)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armor/f13/combat/laserproof
 	name = "ablative combat armor"
@@ -193,6 +195,7 @@
 	armor = list("melee" = 35, "bullet" = 50, "laser" = 45, "energy" = 15, "bomb" = 25, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 25)
 	slowdown = 0.16
 	mutantrace_variation = NONE
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armor/f13/combat/mk2
 	name = "reinforced combat armor"
@@ -204,6 +207,7 @@
 	slowdown = 0.14
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 10)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armor/f13/combat/mk2/dark
 	name = "reinforced combat armor"
@@ -261,6 +265,7 @@
 	icon_state = "combat_armor_raider"
 	item_state = "combat_armor_raider"
 	mutantrace_variation = STYLE_DIGITIGRADE
+	damage_threshold = DT_BASIC // Gives raider a viable choice.
 
 /////////////////
 // Power armor //
@@ -283,6 +288,7 @@
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 20)
 	salvage_tool_behavior = TOOL_WELDER
+	damage_threshold = DT_MAX // Best DT you can get.
 	/// Cell that is currently installed in the suit
 	var/obj/item/stock_parts/cell/cell = /obj/item/stock_parts/cell/high
 	/// How much power the cell consumes each process tick
@@ -829,6 +835,7 @@
 	item_state = "sulphite"
 	armor = list("melee" = 40, "bullet" = 45, "laser" = 55, "energy" = 15, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 0, "wound" = 25)
 	slowdown = 0.18
+	damage_threshold = DT_STRONG // Suphite quality.
 
 /obj/item/clothing/suit/toggle/armor
 	body_parts_covered = CHEST|GROIN
@@ -884,6 +891,7 @@
 	icon = 'icons/fallout/clothing/armored_light.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_light.dmi'
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets
+	damage_threshold = DT_STRONG // Slowdown with that stat line means its a rare high quality armor.
 
 /obj/item/clothing/suit/armor/f13/battlecoat/vault
 	name = "command coat"
@@ -1069,6 +1077,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE
 	armor = list("melee" = 50, "bullet" = 35, "laser" = 50, "energy" = 15, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 0, "wound" = 25)
 	slowdown = 0.12
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/f13/tribal/light/whitelegs
 	name = "White Legs light armour"
@@ -1179,6 +1188,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE
 	armor = list("melee" = 55, "bullet" = 30, "laser" = 40, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 0, "wound" = 25)
 	slowdown = 0.12
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/f13/tribal/light/westernwayfarer
 	name = "Western Wayfarer salvaged armor"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -43,6 +43,7 @@
 	flash_protect = 2
 	slowdown = 0.14
 	mutantrace_variation = STYLE_DIGITIGRADE
+	damage_threshold = DT_BASIC // Has near heavy armor slowdown.
 
 /obj/item/clothing/suit/armor/f13/raider/yankee
 	name = "yankee raider armor"
@@ -113,6 +114,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE
 	armor = list("melee" = 45, "bullet" = 50, "laser" = 45, "energy" = 15, "bomb" = 20, "bio" = 10, "rad" = 10, "fire" = 20, "acid" = 0, "wound" = 20)
 	slowdown = 0.14
+	damage_threshold = DT_BASIC // Has near heavy armor slowdown.
 
 /obj/item/clothing/suit/armor/f13/raider/combatduster/patrolduster
 	name = "Patrol Duster"
@@ -460,6 +462,7 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/bulletbelt
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 8)
 	slowdown = 0.25		//0.35 with helmet
+	damage_threshold = DT_ADVANCED // Salvaged PA
 
 /obj/item/clothing/suit/armor/f13/ncr/heavygunner						//NCR Heavy Gunner armor, Flamethrower loadout
 	name = "\improper NCR heavy plate vest"
@@ -471,6 +474,7 @@
 	armor = list("melee" = 45, "bullet" = 45, "laser" = 35, "energy" = 15, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0, "wound" = 45)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 8)
 	slowdown = 0.18		//0.22 with helmet
+	damage_threshold = DT_STRONG
 
 /obj/item/clothing/suit/armor/f13/ncr/heavygunner/trenchraider //NCR Trench-Raider kit
 	name = "\improper NCR trench-raider plate vest"
@@ -482,6 +486,7 @@
 	armor = list("melee" = 55, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0, "wound" = 40)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 8)
 	slowdown = 0.15		//0.18 with helmet
+	damage_threshold = DT_STRONG
 
 //OFFICER ROLES
 /obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer						//NCR Lieutenant armor
@@ -492,6 +497,7 @@
 	armor = list("melee" = 30, "bullet" = 45, "laser" = 35, "energy" = 15, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0, "wound" = 40)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 8)
 	slowdown = 0.14
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armor/f13/ncr/reinforced/mantle/officer/captain				//NCR Captain Armor
 	name = "\improper NCR reinforced officer mantle vest"
@@ -657,6 +663,7 @@
 	item_state = "brotherhood_armor_captain"
 	armor = list("melee" = 55, "bullet" = 55, "laser" = 65, "energy" = 30, "bomb" = 30, "bio" = 25, "rad" = 25, "fire" = 30, "acid" = 0, "wound" = 30)
 	slowdown = 0.15
+	damage_threshold = DT_ADVANCED // Brotherhood quality
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate
 	name = "initiate armor"
@@ -674,6 +681,7 @@
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 55, "energy" = 25, "bomb" = 25, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 25)
 	slowdown = 0.15
 	mutantrace_variation = STYLE_DIGITIGRADE
+	damage_threshold = DT_STRONG //Brotherhood quality.
 
 //Oasis/Town
 /obj/item/clothing/suit/armor/f13/town
@@ -700,6 +708,7 @@
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45,  "energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0, "wound" = 30)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/holdout
 	slowdown = 0.14
+	damage_threshold = DT_STRONG // Unique
 
 /obj/item/clothing/suit/armor/f13/town/chief
 	name = "BPD Chief's jacket"
@@ -711,6 +720,7 @@
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45,  "energy" = 20, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0, "wound" = 30)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/holdout
 	slowdown = 0.14
+	damage_threshold = DT_STRONG // Unique
 
 /obj/item/clothing/suit/armor/f13/town/deputy
 	name = "armored town trenchcoat"
@@ -719,6 +729,7 @@
 	armor = list("melee" = 40, "bullet" = 50, "laser" = 40,  "energy" = 15, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 0, "wound" = 25)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/holdout
 	slowdown = 0.12
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armor/vest/oasis
 	name = "\improper BPD vest"
@@ -728,6 +739,7 @@
 	armor = list("melee" = 40, "bullet" = 50, "laser" = 40,  "energy" = 15, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 0, "wound" = 25)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets
 	slowdown = 0.12
+	damage_threshold = DT_BASIC
 
 /obj/item/clothing/suit/armor/f13/metalarmor/steelbib/oasis
 	name = "heavy steel breastplate"

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -367,6 +367,7 @@
 	armor = list("melee" = 45, "bullet" = 45, "laser" = 50, "energy" = 25, "bomb" = 35, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 0, "wound" = 45)
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small
 	slowdown = 0.15
+	damage_threshold = DT_BASIC
 
 
 // --------------------------------------------------------------------------
@@ -590,6 +591,7 @@
 	item_state = "follower_heavy"
 	armor = list("melee" = 45, "bullet" = 45, "laser" = 35, "energy" = 20, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20, "wound" = 10)
 	slowdown = 0.12
+	damage_threshold = DT_STRONG // Followers quality
 
 /obj/item/clothing/suit/hooded/followerheavy/followerheavy/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -13,6 +13,7 @@
 	item_state = "sulphite"
 	armor = list("melee" = 55, "bullet" = 40, "laser" = 50, "energy" = 20, "bomb" = 30, "bio" = 25, "rad" = 30, "fire" = 95, "acid" = 15)
 	resistance_flags = FIRE_PROOF
+	damage_threshold = DT_STRONG // It's sulphite, raider made be damned.
 
 /obj/item/clothing/suit/armored/heavy/metal
 	name = "metal armor suit"
@@ -26,6 +27,7 @@
 	desc = "Taking pieces off from a wrecked power armor will at least give you thick plating, but don't expect too much of this shot up, piecemeal armor.."
 	icon_state = "recycled_power"
 	armor = list("melee" = 50, "bullet" = 45, "laser" = 30, "energy" = 10, "bomb" = 35, "bio" = 5, "rad" = 15, "fire" = 15, "acid" = 5, "wound" = 10)
+	damage_threshold = DT_ADVANCED // Still SPA
 
 /obj/item/clothing/suit/armored/heavy/raidermetal
 	name = "iron raider suit"
@@ -33,12 +35,14 @@
 	icon_state = "raider_metal"
 	item_state = "raider_metal"
 	armor = list("melee" = 55, "bullet" = 40, "laser" = 15, "energy" = 5, "bomb" = 25, "bio" = 0, "rad" = 15, "fire" = 20, "acid" = 0, "wound" = 10)
+	damage_threshold = DT_STRONG
 
 /obj/item/clothing/suit/armored/heavy/wardenplate
 	name = "warden plates"
 	desc = "Thick metal breastplate with a decorative skull on the shoulder."
 	icon_state = "wardenplate"
 	armor = list("melee" = 55, "bullet" = 50, "laser" = 35, "energy" = 10, "bomb" = 30, "bio" = 0, "rad" = 15, "fire" = 10, "acid" = 10, "wound" = 10)
+	damage_threshold = DT_STRONG
 
 /obj/item/clothing/suit/armored/heavy/bosexile
 	name = "modified Brotherhood armor"
@@ -46,6 +50,7 @@
 	icon_state = "exile_bos"
 	item_state = "exile_bos"
 	armor = list("melee" = 30, "bullet" = 40, "laser" = 40, "energy" = 20, "bomb" = 25, "bio" = 10, "rad" = 10, "fire" = 20, "acid" = 10, "wound" = 10)
+	damage_threshold = DT_STRONG // Brotherhood quality
 
 /obj/item/clothing/suit/armored/heavy/riotpolice
 	name = "riot police armor"
@@ -62,6 +67,7 @@
 	item_state = "tribal_heavy"
 	armor = list("melee" = 55, "bullet" = 20, "laser" = 25, "energy" = 5, "bomb" = 45, "bio" = 5, "rad" = 10, "fire" = 30, "acid" = 10, "wound" = 10)
 	allowed = list(/obj/item/twohanded, /obj/item/melee/onehanded, /obj/item/melee/smith, /obj/item/melee/smith/twohand, /obj/item/shield)
+	damage_threshold = DT_STRONG // Give tribals something :V
 
 //////////////////////////
 // Salvaged Power Armor //
@@ -81,6 +87,7 @@
 	It isn't meant to be used, it just dictates procs and all that stuff to the subtypes, such as t45d and so on. \
 	Now begone, report this to coders. NOW!"
 	slowdown = 0.35	//When helmeted, 0.45
+	damage_threshold = DT_ADVANCED // Salvaged PA, still PA.
 
 // T-45D
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d
@@ -167,6 +174,7 @@
 	icon_state = "legion_heavy"
 	item_state = "legion_heavy"
 	armor = list("melee" = 65, "bullet" = 45, "laser" = 30, "energy" = 10, "bomb" = 30, "bio" = 20, "rad" = 25, "fire" = 30, "acid" = 5, "wound" = 10)
+	damage_threshold = DT_STRONG
 
 /obj/item/clothing/suit/armored/heavy/legion/centurion
 	name = "legion centurion armor"
@@ -175,12 +183,14 @@
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 35, "energy" = 10, "bomb" = 45, "bio" = 20, "rad" = 20, "fire" = 45, "acid" = 45, "wound" = 32)
 	slowdown = 0.1
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 10) // Rest in pieces
+	damage_threshold = DT_STRONG
 
 /obj/item/clothing/suit/armored/heavy/legion/palacent
 	name = "paladin-slayer centurion armor"
 	desc = "The armor of a Centurion who has bested one or more Brotherhood Paladins, adding pieces of his prizes to his own defense. The symbol of the Legion is crudely painted on this once-marvelous suit of armor."
 	icon_state = "legion_palacent"
 	armor = list("melee" = 55, "bullet" = 45, "laser" = 70, "energy" = 40, "bomb" = 55, "bio" = 20, "rad" = 20, "fire" = 25, "acid" = 0, "wound" = 45)
+	damage_threshold = DT_STRONG
 
 /obj/item/clothing/suit/armored/heavy/legion/rangercent
 	name = "ranger-hunter centurion armor"
@@ -189,6 +199,7 @@
 	item_state = "legion_rangercent"
 	armor = list("melee" = 40, "bullet" = 45, "laser" = 25, "energy" = 10, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 20, "wound" = 35) //Mimics vet ranger stuff, higher melee and lower laser
 	slowdown = 0.03
+	damage_threshold = DT_STRONG
 
 /obj/item/clothing/suit/armored/heavy/legion/legate
 	name = "legion legate armor"
@@ -196,6 +207,7 @@
 	icon_state = "legion_legate"
 	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 10, "bomb" = 45, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0, "wound" = 10)
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 15) // Wouldn't it be hilarious if we just tore apart the Legate's armor?
+	damage_threshold = DT_ADVANCED // Very unique, deserves this given its stat line.
 
 /*
 

--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -693,6 +693,7 @@ Mayor
 	gloves =		/obj/item/clothing/gloves/fingerless
 	shoes = 		/obj/item/clothing/shoes/jackboots
 	r_pocket = 		/obj/item/flashlight/flare
+	r_hand = /obj/item/melee/onehanded/knife/hunting
 
 	backpack =		/obj/item/storage/backpack/cultpack
 	satchel = 		/obj/item/storage/backpack/cultpack


### PR DESCRIPTION
-Added armor defines for 4 tiers of damage threshold.
-All heavy armor and most armor with 0.15 (or close) slowdown has gotten DT 5 or greater.
-- As a general rule, common and crappy heavy armor gets 5. Refined or mid tier heavy gets 10. Salvaged power armor and equal armor gets 15. Full blown working PA gets 20. I was a little generous with some faction armor that was at 0.12-0.14 slowdown, depending on how unique it was.
-Also fixed a bug with loadout generation on preacher by adding a hunting knife (town standard) as they were missing a knife to the right hand on spawn.
-Checks examined clothing to see if it has damage threshold and that the damage threshold is greater than 0, if so it displays the exact DT amount on return text so players know what has DT, what amount, and how much.

## About The Pull Request

This does not add new code but just enables existing code to function. 

## Why It's Good For The Game

Speed is king in PvE and PvP, this makes heavier armor much more impactful and more enticing, in particular for melee builds that either go up against heavy hitters often due to how dangerous mobs are in PvE or have to rush down gun lines in PvP. Generally the biggest impact can be seen with salvaged power armor and regular power armor, those get DT 15 and 20 respectively. Faction heavy armor, due to being unique per job, also got a little more generous DT values of 10 and in some rare cases 15.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
