### PR TITLE
Perk Unlocks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -273,7 +273,7 @@
 #define TRAIT_CYBERNETICIST_EXPERT	"Cyberneticist Expert" //Can augument people into robots directly
 #define TRAIT_MACHINE_SPIRITS	"machine_spirits" //for tribe unique functions.
 #define TRAIT_HARD_YARDS        "hard_yards" //trekking, removes slowdown on all tiles
-#define	TRAIT_LIFEGIVER			"lifegiver" //boosts HP
+#define TRAIT_LIFEGIVER			"lifegiver" //boosts HP
 #define TRAIT_MARS_TEACH		"mars_teachings" //for legion unique functions
 #define TRAIT_EXPLOSIVE_CRAFTING "explosive_crafting" //can craft explosives and bombs
 #define TRAIT_ADVANCED_EXPLOSIVE_CRAFTING "advanced explosive crafting" //can craft almost all kinds of explosives

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -183,7 +183,7 @@
 /datum/quirk/bloodpressure
 	name = "Polycythemia vera"
 	desc = "You've a treated form of Polycythemia vera that increases the total blood volume inside of you as well as the rate of replenishment!"
-	value = 2 //I honeslty dunno if this is a good trait? I just means you use more of medbays blood and make janitors madder, but you also regen blood a lil faster.
+	value = 1 //I honeslty dunno if this is a good trait? I just means you use more of medbays blood and make janitors madder, but you also regen blood a lil faster.
 	mob_trait = TRAIT_HIGH_BLOOD
 	gain_text = "<span class='notice'>You feel full of blood!</span>"
 	lose_text = "<span class='notice'>You feel like your blood pressure went down.</span>"
@@ -200,11 +200,11 @@
 /datum/quirk/tribal_tech
 	name = "Primitive Tech"
 	desc = "You're able to use primitive technology."
-	value = 2
+	value = 1
 	mob_trait = TRAIT_MACHINE_SPIRITS
 	gain_text = "<span class='notice'>You are now able to use primitive technology.</span>"
 	lose_text = "<span class='danger'>You are no longer able to use primitive technology.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/night_vision
 	name = "Night Vision"
@@ -213,7 +213,7 @@
 	mob_trait = TRAIT_NIGHT_VISION
 	gain_text = "<span class='notice'>The shadows seem a little less dark.</span>"
 	lose_text = "<span class='danger'>Everything seems a little darker.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/night_vision/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -248,7 +248,7 @@
 	mob_trait = TRAIT_TRAPPER
 	gain_text = "<span class='notice'>You learn the secrets of butchering!</span>"
 	lose_text = "<span class='danger'>You forget how to slaughter animals.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/bigleagues
 	name = "Big Leagues"
@@ -257,7 +257,7 @@
 	mob_trait = TRAIT_BIG_LEAGUES
 	gain_text = "<span class='notice'>You feel like swinging for the fences!</span>"
 	lose_text = "<span class='danger'>You feel like bunting.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/chemwhiz
 	name = "Chem Whiz"
@@ -266,7 +266,7 @@
 	mob_trait = TRAIT_CHEMWHIZ
 	gain_text = "<span class='notice'>The mysteries of chemistry are revealed to you.</span>"
 	lose_text = "<span class='danger'>You forget how the periodic table works.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/pa_wear
 	name = "PA Wear"
@@ -275,7 +275,7 @@
 	mob_trait = TRAIT_PA_WEAR
 	gain_text = "<span class='notice'>You realize how to use Power Armor.</span>"
 	lose_text = "<span class='danger'>You forget how Power Armor works.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/hard_yards
 	name = "Hard Yards"
@@ -284,7 +284,7 @@
 	mob_trait = TRAIT_HARD_YARDS
 	gain_text = "<span class='notice'>Rain or shine, nothing slows you down.</span>"
 	lose_text = "<span class='danger'>You walk with a less sure gait, the ground seeming less firm somehow.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/lifegiver
 	name = "Lifegiver"
@@ -293,7 +293,7 @@
 	mob_trait = TRAIT_LIFEGIVER
 	gain_text = "<span class='notice'>You feel more healthy than usual.</span>"
 	lose_text = "<span class='danger'>You feel less healthy than usual.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/lifegiver/on_spawn()
 	var/mob/living/carbon/human/mob_tar = quirk_holder
@@ -307,7 +307,7 @@
 	mob_trait = TRAIT_IRONFIST
 	gain_text = "<span class='notice'>Your fists feel furious!</span>"
 	lose_text = "<span class='danger'>Your fists feel calm again.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/light_step
 	name = "Light Step"
@@ -329,20 +329,20 @@
 /datum/quirk/surgerymid
 	name = "Intermediate Surgery"
 	desc = "You are a skilled medical practicioner, capable of performing most surgery."
-	value = 1
+	value = 2
 	mob_trait = TRAIT_SURGERY_MID
 	gain_text = "<span class='notice'>You feel yourself discovering most of the details of the human body.</span>"
 	lose_text = "<span class='danger'>You forget how to perform surgery.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/surgeryhigh
 	name = "Complex Surgery"
 	desc = "You are an expert practicioner, capable of performing almost all surgery."
-	value = 1
+	value = 3
 	mob_trait = TRAIT_SURGERY_HIGH
 	gain_text = "<span class='notice'>You feel yourself discovering the most intricate secrets of the human body.</span>"
 	lose_text = "<span class='danger'>You forget your advanced surgical knowledge.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/explosive_crafting
 	name = "Explosives Crafting"
@@ -351,7 +351,7 @@
 	mob_trait = TRAIT_EXPLOSIVE_CRAFTING
 	gain_text = "<span class='notice'>You feel like you can make a bomb out of anything.</span>"
 	lose_text = "<span class='danger'You feel okay with the advancement of technology.</span>"
-	locked = TRUE
+	//locked = TRUE
 
 /datum/quirk/advanced_explosive_crafting
 	name = "Advanced Explosive Crafting"
@@ -360,4 +360,4 @@
 	mob_trait = TRAIT_ADVANCED_EXPLOSIVE_CRAFTING
 	gain_text = "<span class='notice'>You're on the no-fly list.'</span>"
 	lose_text = "<span class='danger'You feel like you're allowed to fly on planes again.</span>"
-	locked = TRUE
+	//locked = TRUE

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -267,7 +267,7 @@
 	gain_text = "<span class='notice'>The mysteries of chemistry are revealed to you.</span>"
 	lose_text = "<span class='danger'>You forget how the periodic table works.</span>"
 	//locked = TRUE
-
+/*
 /datum/quirk/pa_wear
 	name = "PA Wear"
 	desc = "You've being around the wastes and have learned the importance of defense."
@@ -276,7 +276,7 @@
 	gain_text = "<span class='notice'>You realize how to use Power Armor.</span>"
 	lose_text = "<span class='danger'>You forget how Power Armor works.</span>"
 	//locked = TRUE
-
+*/
 /datum/quirk/hard_yards
 	name = "Hard Yards"
 	desc = "You've put them in, now reap the rewards."

--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -112,12 +112,12 @@ Mayor
 	head = /obj/item/clothing/head/helmet/f13/enclave/usmcriot/dusty
 	l_pocket = /obj/item/storage/bag/money/small/bighorn
 	r_pocket = /obj/item/flashlight/flare
+	l_hand = /obj/item/melee/classic_baton
+	r_hand = /obj/item/melee/onehanded/knife/survival
 
 	backpack_contents = list(
-		/obj/item/storage/box/deputy_badges=1, \
-		/obj/item/restraints/handcuffs=1, \
-		/obj/item/melee/classic_baton=1,
-		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/storage/box/deputy_badges = 1, \
+		/obj/item/restraints/handcuffs = 1, \
 		/obj/item/book/granter/crafting_recipe/ODF = 1)
 
 /datum/outfit/job/bighorn/f13sheriff/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION
Character creation at present is... empty? Barely any options. I'd like to open it up to give some variation, we're not exactly a pvp server, which is primarily why dusty trails disabled the perks in the most lazy way. All I did was re-enable them and make the slightly more useless ones cost less, so their easier to take for flavor.

-More blood perk now cost 1 point, down from 2.
-Tribal tech now costs 1 point, down from 2.
-Surgery perks now scale, 1-2-3 per level.
-Fixed a backpack load issue with lieutenant by moving 2 items from his backpack to his hands.