### PR TITLE
Widowmaker spawns witht buckshots (Shotgun internal mag code small cleanup/tweak)

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/magazine/internal/shot
 	name = "shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	caliber = "shotgun"
 	max_ammo = 4
 	multiload = 0
@@ -15,17 +15,14 @@
 	else
 		return ..()
 /obj/item/ammo_box/magazine/internal/shot/trench
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 5
 
 /obj/item/ammo_box/magazine/internal/shot/tube
 	name = "dual feed shotgun internal tube"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/shot/tube_noalt
 	name = "dual feed shotgun internal tube"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 12
 
 /obj/item/ammo_box/magazine/internal/shot/lethal
@@ -33,17 +30,14 @@
 
 /obj/item/ammo_box/magazine/internal/shot/com
 	name = "combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/shot/com/compact
 	name = "compact combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/shot/com/citykiller
 	name = "city killer shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 10
 
 /obj/item/ammo_box/magazine/internal/shot/dual
@@ -61,7 +55,6 @@
 
 /obj/item/ammo_box/magazine/internal/shot/police
 	name = "police shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/internal/shot/bounty
@@ -96,7 +89,6 @@
 
 /obj/item/ammo_box/magazine/internal/shot/pardner
 	name = "single shotgun internal tube"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	max_ammo = 1
 
 /obj/item/ammo_box/magazine/internal/plasmacaster


### PR DESCRIPTION
## About The Pull Request

Remnant SS13 code cleanup(Just replacing the default ammo being loaded with buckshot instead of beanbag).

## Why It's Good For The Game

For years all shotguns had been loaded with buckshots and improvised ammo by default, but what about the immortal classics of classics? As this obviously isn't SS13 anymore, Widowmakers(double-barreled shotgun) no longer spawns loaded with beanbags to now be loaded with buckshots instead.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: The Widowmaker should be loaded with buckshots as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
