### PR TITLE
Brotherhood Helmet fix

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -321,6 +321,7 @@
 		/obj/item/clothing/head/helmet/f13/combat/rangerbroken,
 		/obj/item/clothing/head/helmet/f13/combat/swat,
 		/obj/item/clothing/head/helmet/f13/combat/environmental,
+		/obj/item/clothing/head/helmet/f13/combat/brotherhood,
 	)
 	reqs = list(/obj/item/clothing/head/helmet/f13/combat = 1,
 				/obj/item/toy/crayon/spraycan)
@@ -1343,6 +1344,7 @@
 		/obj/item/clothing/head/helmet/f13/combat/rangerbroken,
 		/obj/item/clothing/head/helmet/f13/combat/swat,
 		/obj/item/clothing/head/helmet/f13/combat/environmental,
+		/obj/item/clothing/head/helmet/f13/combat/brotherhood,
 	)
 	reqs = list(
 		/obj/item/clothing/head/helmet/f13/combat = 1,
@@ -1410,6 +1412,7 @@
 		/obj/item/clothing/head/helmet/f13/combat/rangerbroken,
 		/obj/item/clothing/head/helmet/f13/combat/swat,
 		/obj/item/clothing/head/helmet/f13/combat/environmental,
+		/obj/item/clothing/head/helmet/f13/combat/brotherhood,
 	)
 	reqs = list(
 		/obj/item/clothing/head/helmet/f13/combat = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Blacklists the Brotherhood helmet from the combat armor repainting recipes because it has different stats.

## Why It's Good For The Game

Doesn't result in you making the Brotherhood helmet into a weaker combat armor helmet.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->