### PR TITLE
Omni Fixes

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -273,6 +273,7 @@
 #define TRAIT_CYBERNETICIST_EXPERT	"Cyberneticist Expert" //Can augument people into robots directly
 #define TRAIT_MACHINE_SPIRITS	"machine_spirits" //for tribe unique functions.
 #define TRAIT_HARD_YARDS        "hard_yards" //trekking, removes slowdown on all tiles
+#define TRAIT_SOFT_FEET        "soft_feet" // slow you the fuck down
 #define TRAIT_LIFEGIVER			"lifegiver" //boosts HP
 #define TRAIT_MARS_TEACH		"mars_teachings" //for legion unique functions
 #define TRAIT_EXPLOSIVE_CRAFTING "explosive_crafting" //can craft explosives and bombs

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -278,8 +278,8 @@
 	//locked = TRUE
 */
 /datum/quirk/hard_yards
-	name = "Hard Yards"
-	desc = "You've put them in, now reap the rewards."
+	name = "Wasteland Maneuvers"
+	desc = "You know how to get around the wasteland, you ignore the slowdown effects of terrain."
 	value = 3
 	mob_trait = TRAIT_HARD_YARDS
 	gain_text = "<span class='notice'>Rain or shine, nothing slows you down.</span>"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -309,6 +309,14 @@
 	lose_text = "<span class='danger'>Your fists feel calm again.</span>"
 	//locked = TRUE
 
+/datum/quirk/perfect_attacker
+	name = "Perfect Striker"
+	desc = "Your strikes are flawless, you always deal maximum damage with unarmed attacks."
+	value = 2
+	mob_trait = TRAIT_PERFECT_ATTACKER
+	gain_text = "<span class='notice'>Your punches never miss!</span>"
+	lose_text = "<span class='danger'>Your strikes feel a bit clumsy.</span>"
+
 /datum/quirk/light_step
 	name = "Light Step"
 	desc = "You walk with a gentle step, making stepping on sharp objects quieter and less painful."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -393,3 +393,11 @@
 	mob_trait = TRAIT_SHACKLEDRUNNING
 	gain_text = "<span class='notice'>You feel very clumsy!</span>"
 	lose_text = "<span class='danger'>You feel more agile.</span>"
+
+/datum/quirk/soft_feet
+	name = "Wasteland Bumbler"
+	desc = "No matter how much you try, you never seem to be able to find proper footing. Terrain slowdown is much greater."
+	value = -3
+	mob_trait = TRAIT_SOFT_FEET
+	gain_text = "<span class='notice'>Your footing always seems to pick the worst spot to step!</span>"
+	lose_text = "<span class='danger'>The ground feels a bit more firm.</span>"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1084,6 +1084,12 @@
 				granted_trait = TRAIT_BIG_LEAGUES
 				traitname = "hitting things"
 				remarks = list("Grognak hit the Death Knight only once, but that was enough.", "Grognak is surprisingly agile, never committing too heavily on an attack, dancing between his enemies.", "Grognak isn't good at talking, but he knows it has its place. He has friends to talk for him.", "Other barbarians might change their weapons, but Grognak could never leave his beloved axe.")
+
+	if(HAS_TRAIT(user, granted_trait))
+		to_chat(user, "<span class ='notice'>You already have all the insight you need about [traitname].")
+		granted_trait = null
+		return FALSE
+
 	return ..()
 
 

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -968,3 +968,5 @@
 	icon_state = "dusty_lieutenant"
 	item_state = "dusty_lieutenant"
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 35, "bomb" = 20, "bio" = 25, "rad" = 25, "fire" = 20, "acid" = 20, "wound" = 30)
+	slowdown = 0.14
+	damage_threshold = DT_STRONG // Unique

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -56,10 +56,17 @@
 	add_movespeed_modifier((m_intent == MOVE_INTENT_WALK)? /datum/movespeed_modifier/config_walk_run/walk : /datum/movespeed_modifier/config_walk_run/run)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)
-	if(isopenturf(T) && !HAS_TRAIT(src, TRAIT_HARD_YARDS))
+	if(isopenturf(T))
+		if(HAS_TRAIT(src, TRAIT_HARD_YARDS) && !HAS_TRAIT(src, TRAIT_SOFT_FEET))
+			remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
+			return
+		if(HAS_TRAIT(src, TRAIT_SOFT_FEET))
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = (T.slowdown * 2.5))
+			return
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = T.slowdown)
-	else
-		remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
+		return
+	remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
+
 
 /mob/living/proc/update_special_speed(speed)//SPECIAL Integration
 	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/special_speed, multiplicative_slowdown = speed)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -61,7 +61,7 @@
 			remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
 			return
 		if(HAS_TRAIT(src, TRAIT_SOFT_FEET))
-			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = (T.slowdown * 2.5))
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = (T.slowdown * 3))
 			return
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = T.slowdown)
 		return


### PR DESCRIPTION
-Hard Yards is now named Wasteland Maneuvers and its description actually tells you what it does. 
-Burned books now verify if you have a granted trait and if so do not try to re-grant said trait (which would bug out and make the book impossible to use or drop) 
-Sheriff riot armor is now properly classed as heavy armor, given 0.14 slowdown and DT_STRONG.
-Added a new negative perk called Wasteland Bumbler, that increases terrain slowdown by x3 for -3 points. 
-Rewrote the turf movespeed code to allow for modular changes in case we add more terrain movement perks.
-Added perfect attacker to the perk list under the name "Perfect Striker" for 2 points. It maxes out your unarmed damage from 1-10 to always roll ten. Yes, for those paying attention, when combined with iron fist you can get a base unarmed damage of 16 before fist/gauntlet weapons are added.

**NOTE**: In most cases taking oppositional perks simply cancel each other out due to being equal cost in points and bonus, in the case of wasteland bumbler I added a new check that outright cancels wasteland maneuvers. This was done because A) Maneuvers is a flat removal and B) A fuck ton of jobs get wasteland maneuvers automatically. The whole legion, sheriff, multiple ncr jobs, khan senior enforcer, and a few misc jobs all gain wastelander maneuvers by default. Rather than blacklist said perks, you can still take wasteland bumbler, but technically at a much greater penalty, as you open the job to slowdown entirely.

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.