### PR TITLE
Raider Plus: Prepare to Die Edition

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -265,6 +265,7 @@
 #define TRAIT_BERSERKER			"berserker"
 #define TRAIT_TECHNOPHREAK		"technophreak"	//boosts salvage return
 #define TRAIT_PA_WEAR           "pa_wear" //guess
+#define TRAIT_RAIDER_ARMOR		"raider_wear" // prevents you from wearing any armor that isn't raider armor
 #define TRAIT_MEDICALEXPERT		"Medicinal Expert" //Can do revival surgery
 #define TRAIT_MEDICALGRADUATE		"Medical Graduate" //generalised offmap medschool graduation training
 #define TRAIT_UNETHICAL_PRACTITIONER	"Unethical Practitioner" //Can do harmful experimental surguries

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -26,6 +26,7 @@
 	var/lighting_alpha
 	var/glass_colour_type //colors your vision when worn
 	var/damage_threshold = 0
+	var/raider_armor = FALSE
 
 
 	var/blocks_shove_knockdown = FALSE //Whether wearing the clothing item blocks the ability for shove to knock down.
@@ -469,6 +470,10 @@ BLIND     // can't see anything
 			if(!wearable)
 				to_chat(M, "<span class='warning'>Your species cannot wear [src].</span>")
 				return FALSE
+
+	if(HAS_TRAIT(M, TRAIT_RAIDER_ARMOR) && !raider_armor && slot_flags == ITEM_SLOT_OCLOTHING)
+		to_chat(M, "<span class='warning'>You can't wear this! You're a badass raider and need to look the part!</span>")
+		return 0
 
 	return TRUE
 

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -266,6 +266,7 @@
 	item_state = "combat_armor_raider"
 	mutantrace_variation = STYLE_DIGITIGRADE
 	damage_threshold = DT_BASIC // Gives raider a viable choice.
+	raider_armor = TRUE
 
 /////////////////
 // Power armor //
@@ -836,6 +837,7 @@
 	armor = list("melee" = 40, "bullet" = 45, "laser" = 55, "energy" = 15, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 0, "wound" = 25)
 	slowdown = 0.18
 	damage_threshold = DT_STRONG // Suphite quality.
+	raider_armor = TRUE // technically raider armor.
 
 /obj/item/clothing/suit/toggle/armor
 	body_parts_covered = CHEST|GROIN
@@ -879,6 +881,7 @@
 	strip_delay = 40
 	icon = 'icons/fallout/clothing/armored_medium.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_medium.dmi'
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armor/f13/battlecoat //Maxson's battlecoat from Fallout 4
 	name = "battlecoat"

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -166,6 +166,7 @@
 	item_state = "raider_combat"
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 10, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 0, "wound" = 15)
 	slowdown = 0.1
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armor/f13/raider/raidermetal
 	name = "metal raider armor"
@@ -174,6 +175,7 @@
 	item_state = "raider_metal"
 	armor = list("melee" = 55, "bullet" = 55, "laser" = 35, "energy" = 15, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 0, "wound" = 25)
 	slowdown = 0.2
+	raider_armor = TRUE
 
 //////////
 //LEGION//

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -10,6 +10,7 @@
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 5, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 0, "wound" = 15)
 	strip_delay = 40
 	slowdown = 0.06
+	raider_armor = TRUE // Applies to all subtypes.
 
 /obj/item/clothing/suit/armor/f13/raider/supafly //melee spec
 	name = "supa-fly raider armor"
@@ -66,7 +67,7 @@
 	AddComponent(/datum/component/armor_plate)
 
 /obj/item/clothing/suit/armor/f13/raider/jackal
-	name = "Jackal armored rags"
+	name = "Jackal armored raider rags"
 	desc = "A collection of spare rags and cloth sewn together into a robe-like uniform and pants, sporting a half-complete combat armor set over-top."
 	icon_state = "jackal"
 	item_state = "jackal"
@@ -79,7 +80,7 @@
 	AddComponent(/datum/component/armor_plate)
 
 /obj/item/clothing/suit/armor/f13/raider/ncrcfarmor
-	name = "NCRCF armored jacket"
+	name = "NCRCF armored raider jacket"
 	desc = "An NCR Correctional Facility jacket worn overtop of a worn bullet proof vest. Simple, yet effective."
 	icon_state = "ncrcf_armor"
 	item_state = "ncrcf_armor"
@@ -107,7 +108,7 @@
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 45, "energy" = 5, "bomb" = 15, "bio" = 60, "rad" = 40, "fire" = 15, "acid" = 0, "wound" = 15)
 
 /obj/item/clothing/suit/armor/f13/raider/combatduster
-	name = "combat duster"
+	name = "raider combat duster"
 	desc = "An old military-grade pre-war combat armor under a weathered duster. It appears to be fitted with metal plates to replace the crumbling ceramic."
 	icon_state = "combatduster"
 	item_state = "combatduster"
@@ -117,7 +118,7 @@
 	damage_threshold = DT_BASIC // Has near heavy armor slowdown.
 
 /obj/item/clothing/suit/armor/f13/raider/combatduster/patrolduster
-	name = "Patrol Duster"
+	name = "raider patrol duster"
 	desc = "What appears to be an NCR patrol ranger's armor under a green tinted duster. The armor itself looks much more well kept then the duster itself, said duster looking somewhat faded. On the back of the duster, is a symbol of a skull with an arrow piercing through the eye."
 	icon_state = "patrolduster"
 	item_state = "patrolduster"

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -124,10 +124,11 @@
 	armor = list("melee" = 25, "bullet" = 20, "laser" = 15, "energy" = 5, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 10)
 
 /obj/item/clothing/suit/f13/mfp/raider
-	name = "offbeat jacket"
+	name = "offbeat raider jacket"
 	desc = "A black leather jacket with a single metal shoulder pad on the right side.<br>The right sleeve was obviously ripped or cut away.<br>It looks like it was originally a piece of a Main Force Patrol uniform."
 	icon_state = "mfp_raider"
 	armor = list("melee" = 25, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 10)
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/f13/lonesome
 	name = "lonesome duster"

--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -14,6 +14,7 @@
 	armor = list("melee" = 55, "bullet" = 40, "laser" = 50, "energy" = 20, "bomb" = 30, "bio" = 25, "rad" = 30, "fire" = 95, "acid" = 15)
 	resistance_flags = FIRE_PROOF
 	damage_threshold = DT_STRONG // It's sulphite, raider made be damned.
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/heavy/metal
 	name = "metal armor suit"
@@ -36,6 +37,7 @@
 	item_state = "raider_metal"
 	armor = list("melee" = 55, "bullet" = 40, "laser" = 15, "energy" = 5, "bomb" = 25, "bio" = 0, "rad" = 15, "fire" = 20, "acid" = 0, "wound" = 10)
 	damage_threshold = DT_STRONG
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/heavy/wardenplate
 	name = "warden plates"
@@ -102,6 +104,7 @@
 	desc = "A salvaged set of T-45d power armor, which has been brought back to life with the help of a welder and lots of scrap metal."
 	icon_state = "raider_salvaged"
 	item_state = "raider_salvaged"
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d/hotrod
 	name = "salvaged hotrod power armor"

--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -168,6 +168,7 @@
 	heat_protection = CHEST | GROIN | LEGS| ARMS | HEAD
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 10, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 5, "acid" = 0, "wound" = 10)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/light/tribalraider
 	name = "tribal raider wear"
@@ -176,6 +177,7 @@
 	item_state = "tribal_outcast"
 	heat_protection = CHEST | GROIN | LEGS| ARMS | HEAD
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 15, "energy" = 5, "bomb" = 5, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 0, "wound" = 10)
+	raider_armor = TRUE
 	allowed = list(/obj/item/gun, /obj/item/kitchen, /obj/item/twohanded, /obj/item/melee/onehanded, /obj/item/twohanded/spear, /obj/item/melee/smith, /obj/item/melee/smith/twohand, /obj/item/shield
 	)
 

--- a/code/modules/clothing/suits/medium_armor.dm
+++ b/code/modules/clothing/suits/medium_armor.dm
@@ -100,6 +100,7 @@
 	desc = "Take one set of combat armor, add a classic suit of painspike armor, forget hugging your friends ever again."
 	icon_state = "combat_painspike"
 	item_state = "combat_painspike"
+	raider_armor = TRUE
 
 ////////////
 // OUTLAW //
@@ -112,6 +113,7 @@
 	item_state = "supafly"
 	armor = list("melee" = 25, "bullet" = 40, "laser" = 20, "energy" = 5, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 25, "wound" = 10)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/rebel
 	name = "rebel raider armor"
@@ -119,6 +121,7 @@
 	icon_state = "raider_rebel_icon"
 	item_state = "raider_rebel_armor"
 	armor = list("melee" = 25, "bullet" = 30, "laser" = 20, "energy" = 5, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 20, "wound" = 10)
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/sadist
 	name = "sadist raider armor"
@@ -127,6 +130,7 @@
 	item_state = "sadist"
 	armor = list("melee" = 30, "bullet" = 25, "laser" = 25, "energy" = 10, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 5, "wound" = 10)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/blastmaster
 	name = "blastmaster raider armor"
@@ -136,6 +140,7 @@
 	flash_protect = 2
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 20, "energy" = 5, "bomb" = 60, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 25, "wound" = 10)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/yankee
 	name = "yankee raider armor"
@@ -144,6 +149,7 @@
 	item_state = "yankee"
 	armor = list("melee" = 40, "bullet" = 20, "laser" = 15, "energy" = 5, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 25, "wound" = 10)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/painspike
 	name = "painspike raider armor"
@@ -152,6 +158,7 @@
 	item_state = "painspike"
 	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 0, "bomb" = 5, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 5, "wound" = 10)
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/iconoclast
 	name = "iconoclast raider armor"
@@ -160,6 +167,7 @@
 	item_state = "iconoclast"
 	permeability_coefficient = 0.8
 	armor = list("melee" = 25, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 30, "bio" = 40, "rad" = 60, "fire" = 25, "acid" = 40)
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/khancoat
 	name = "khan battlecoat"
@@ -206,13 +214,15 @@
 	cold_protection = CHEST | GROIN | LEGS| ARMS | HEAD
 	siemens_coefficient = 0.9
 	armor = list("melee" = 45, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 40, "bio" = 10, "rad" = 10, "fire" = -25, "acid" = 0, "wound" = 10)
+	raider_armor = TRUE
 
 /obj/item/clothing/suit/armored/medium/scrapcombat
-	name = "scrap combat armor"
+	name = "scrap raider combat armor"
 	desc = "Scavenged military combat armor, repaired by unskilled hands many times, most of the original plating having cracked or crumbled to dust."
 	icon_state = "raider_combat"
 	item_state = "raider_combat"
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 15, "energy" = 5, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 5, "wound" = 10)
+	raider_armor = TRUE
 
 
 ////////////

--- a/code/modules/jobs/job_types/raider.dm
+++ b/code/modules/jobs/job_types/raider.dm
@@ -47,13 +47,13 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	/datum/outfit/loadout/raider_badlands,
 	/datum/outfit/loadout/raider_powder,
 	/datum/outfit/loadout/raider_smith,
-	/datum/outfit/loadout/raider_sawbones,
-	/datum/outfit/loadout/raider_highway,
-	/datum/outfit/loadout/raider_enclave,
-	/datum/outfit/loadout/raider_bos,
-	/datum/outfit/loadout/raider_ncr,
-	/datum/outfit/loadout/raider_legion,
-	/datum/outfit/loadout/raider_vault,
+	/datum/outfit/loadout/raider_sawbones
+	//datum/outfit/loadout/raider_highway,
+	//datum/outfit/loadout/raider_enclave,
+	//datum/outfit/loadout/raider_bos,
+	//datum/outfit/loadout/raider_ncr,
+	//datum/outfit/loadout/raider_legion,
+	//datum/outfit/loadout/raider_vault,
 	)
 
 /datum/outfit/job/raider/f13raider/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -82,7 +82,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 		)
 
 /datum/outfit/loadout/raider_jackal
-	name = "Jackal"
+	name = "Raider Jackal"
 	suit = /obj/item/clothing/suit/armor/f13/raider/jackal
 	head = /obj/item/clothing/head/helmet/f13/jackal
 	backpack_contents = list(
@@ -97,7 +97,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	)
 
 /datum/outfit/loadout/raider_badlands
-	name = "Fiend"
+	name = "Raider Fiend"
 	suit = /obj/item/clothing/suit/armor/f13/raider/badlands
 	head = /obj/item/clothing/head/helmet/f13/fiend
 	backpack_contents = list(
@@ -113,7 +113,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	)
 
 /datum/outfit/loadout/raider_powder
-	name = "Powder Ganger"
+	name = "Raider Ganger"
 	suit = /obj/item/clothing/suit/armor/f13/raider/ncrcfarmor
 	head = /obj/item/clothing/head/f13/stormchaser
 	uniform = /obj/item/clothing/under/f13/ncrcf
@@ -163,7 +163,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 		/obj/item/defibrillator/primitive=1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
 		)
-
+/*
 /datum/outfit/loadout/raider_highway
 	name = "Highwayman"
 	suit = /obj/item/clothing/suit/f13/cowboygvest
@@ -257,7 +257,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/book/granter/trait/research = 1,
 		)
-
+*/
 
 /*
 Reason this is commented out: Not needed, may re-use loadouts later

--- a/code/modules/jobs/job_types/raider.dm
+++ b/code/modules/jobs/job_types/raider.dm
@@ -19,12 +19,17 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	social_faction = FACTION_RAIDERS
 	exp_requirements = 600
 	exp_type = EXP_TYPE_FALLOUT
-	total_positions = 12
-	spawn_positions = 12
+	total_positions = 3
+	spawn_positions = 3
 	description = "You are a member of the underworld of the La Verkin region, well-established or a newcomer looking to rile things up. \
 	Morals and laws generally mean little to you. Perhaps you are a thief, chem dealer, deserter, or just a garden-variety murderer. \
 	The Den where you have spawned is a good hovel for scum like you, but take your troubles wherever you like. \
-	Run with a gang or make your crimes an independent venture - just remember to make things interesting for others."
+	Run with a gang or make your crimes an independent venture - just remember to make things interesting for others. \
+	OOC: YOU ARE FLAGGED FOR PVP, this is not a license to grief. Follow server rules as written, the only difference is escalation rules are relaxed. \
+	Do not complain if you are killed, you agreed to this by signing up as a raider. \
+	Raid rules still apply to you but not others, anyone can raid your base freely. \
+	You are expected to defend your dungeon but do not gather up all the loot and hide it, take only what you will use and can carry directly on your person. \
+	You are here to make things interesting, not frustrating."
 	supervisors = "No Gods, No Masters!"
 
 	outfit = /datum/outfit/job/raider/f13raider
@@ -57,6 +62,8 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 		return
 
 	H.social_faction = FACTION_RAIDERS
+	H.faction = list("raider")
+	ADD_TRAIT(H, TRAIT_RAIDER_ARMOR,  REF(src))
 
 /datum/outfit/job/raider/f13raider
 	name = "Raider"
@@ -140,7 +147,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 
 /datum/outfit/loadout/raider_sawbones
 	name = "Raider Sawbones"
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/followers
+	suit = /obj/item/clothing/suit/armor/f13/raider/sadist
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_hand = /obj/item/storage/backpack/duffelbag/med/surgery
 	r_hand = /obj/item/book/granter/trait/midsurgery

--- a/code/modules/mob/living/simple_animal/hostile/f13/renegade.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/renegade.dm
@@ -24,7 +24,7 @@
 	attack_verb_simple = "smacks"
 	attack_sound = 'sound/weapons/smash.ogg'
 	a_intent = INTENT_HARM
-	faction = list("raider")
+	faction = list("renegade")
 	check_friendly_fire = TRUE
 	status_flags = CANPUSH
 	del_on_death = FALSE
@@ -327,7 +327,7 @@
 	// therefore setting it to BRUTELOSS | FIRELOSS | TOXLOSS | OXYLOSS would mean healing 4x as much
 	// aka 40% of max life every tick, which is basically unkillable
 	// TODO: refactor this if simple_animals ever get damage types
-	AddComponent(/datum/component/glow_heal, chosen_targets = /mob/living/simple_animal/hostile/renegade, allow_revival = FALSE, restrict_faction = list("raider"), type_healing = BRUTELOSS)
+	AddComponent(/datum/component/glow_heal, chosen_targets = /mob/living/simple_animal/hostile/renegade, allow_revival = FALSE, restrict_faction = list("renegade"), type_healing = BRUTELOSS)
 
 // ADVANCED HEALER VARIANT
 /mob/living/simple_animal/hostile/renegade/doc/medic
@@ -340,7 +340,7 @@
 /mob/living/simple_animal/hostile/raider/junker/boss/renegade
 	name = "Renegade Boss"
 	desc = "A Renegade boss, clad in hotrod power armor, and wielding a deadly rapid-fire shrapnel cannon. He's had enough of your shit."
-	faction = list("raider","wastebot","hostile","supermutant","ghoul")
+	faction = list("renegade")
 	aggro_vision_range = 15
 	armour_penetration = 0.8
 	environment_smash = ENVIRONMENT_SMASH_RWALLS

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -363,7 +363,7 @@
 
 /obj/item/projectile/proc/process_hit(turf/T, atom/target, qdel_self, hit_something = FALSE)		//probably needs to be reworked entirely when pixel movement is done.
 	if(isliving(target) && LAZYLEN(supereffective_faction))
-		var/mob/living/L = target
+		var/mob/living/simple_animal/L = target
 		for(var/F in L.faction)
 			if(F in supereffective_faction)
 				damage += supereffective_damage

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -589,7 +589,7 @@
 	wound_bonus = 35 //being hit with plasma is horrific
 	eyeblur = 0
 	is_reflectable = TRUE
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
+	supereffective_faction = list("renegade", "hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 	supereffective_damage = 36
 	pixels_per_second =  TILES_TO_PIXELS(20)
 

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -98,7 +98,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	wound_bonus = 35
 	bare_wound_bonus = 80
 	supereffective_damage = 150
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
+	supereffective_faction = list("renegade", "hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/a50MG/incendiary
 	damage = 60
@@ -187,7 +187,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	armour_penetration = 0.9
 	pixels_per_second = TILES_TO_PIXELS(100)
 	supereffective_damage = 58
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
+	supereffective_faction = list("renegade", "hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/c2mm/blender //welcome to pain town
 	name = "2mm blender projectile"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -9,7 +9,7 @@
 	spread = 2
 	wound_falloff_tile = -7.5
 	supereffective_damage = 35
-	supereffective_faction = list("hostile", "ant", "supermutant", "cazador", "deathclaw", "raider", "wastebot", "gecko", "radscorpion")
+	supereffective_faction = list("renegade", "hostile", "ant", "supermutant", "cazador", "deathclaw", "raider", "wastebot", "gecko", "radscorpion")
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
@@ -69,7 +69,7 @@
 	bare_wound_bonus = 90
 	wound_falloff_tile = -20 // low damage + additional dropoff will already curb wounding potential anything past point blank
 	supereffective_damage = 3
-	supereffective_faction = list("hostile", "ant", "supermutant", "cazador", "raider", "gecko", "radscorpion")
+	supereffective_faction = list("renegade", "hostile", "ant", "supermutant", "cazador", "raider", "gecko", "radscorpion")
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -19,7 +19,7 @@
 	damage = 20
 	armour_penetration = 0.10
 	supereffective_damage = 40
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
+	supereffective_faction = list("renegade", "hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
 
 /obj/item/projectile/bullet/reusable/arrow/bronze //Just some AP shots
@@ -99,7 +99,7 @@
 	armour_penetration = 0.05
 	damage = 30
 	supereffective_damage = 20 //weaker upfront, but stronger if you can stack the bleed effect
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
+	supereffective_faction = list("renegade", "hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/serrated
 
 /obj/item/projectile/bullet/reusable/arrow/serrated/on_hit(atom/target, blocked)


### PR DESCRIPTION
-Supereffective_damage now only checks against simple_animals, preventing players from getting iced if they somehow have a non-neutral faction. 
-Renegades are no longer allied to raiders and will actively fight each other when seen.
-Junk raiders retain ally status to wastebots, though raiders should now be hostile to all other hostiles except reprogrammed robots. This is explained in lore that junk raiders are capable of communing with the machine spirits. :3
-Every bullet type that had supereffective_damage against raiders now applies to renegades new faction "renegade". 
-All armor with raider in the name now has the raider_armor tag. This does nothing for regular players but effects raider players.
-Raider players are now allied to raider npc mobs and can considered the "raider boss" by default, this allows you to base in locations with raiders safely and use raider npcs as cannon fodder, including killing them for a better weapon (yer the boss after all). 
-Raider job role reduced to a cap of 3.
-Raider players can *only* use raider armor, attempting to equip anything in the suit slot without raider in the name will automatically fail. 
-The raider job role is given an expanded rule set you can read when joining as a raider, including your pvp flag, relaxed escalation rules, and expectations of how you loot and base. In general, you can base in raider dungeons but can be raided without raid rules, treating you and your stash as one does npc raiders.
-All nonraider loadouts are removed (we will eventually remove these with the map change). This includes the enclave, brotherhood, vault, legion, and ncr raider load outs.

In general when playing as a raider you can choose to make your base within a dungeon, this means you have access to its loot and where you'll put your own stash, crafting stations, and other stuff. Just like an npc dungeon, this can be raided freely without following raid rules. You are expected to defend it, either by moving raider npcs around, setting traps, or building fortifications. *However*, raid rules still apply to you and trying to raid defined faction bases without following said rules is considered griefing. If you don't want npc raider protection or just don't want to be raided, pick an obscure/hidden base location or just don't play as a raider. *You are expected to only loot what you can and will carry on your person.*

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
