### PR TITLE
Ferocious Loyalty: Make Leaders actually Leaders

### DIFF
--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -132,6 +132,7 @@ Mayor
 	ADD_TRAIT(H, TRAIT_SELF_AWARE,REF(src))
 	ADD_TRAIT(H, TRAIT_IRONFIST, REF(src))
 	H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
+	H.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
 
 /*--------------------------------------------------------------*/
 /datum/job/bighorn/f13deputy

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -76,6 +76,7 @@ Elder
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ,  REF(src))
 	ADD_TRAIT(H, TRAIT_RESEARCHER,  REF(src))
 	H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
+	H.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
 
 /datum/outfit/job/bos/f13elder
 	name = "Elder"
@@ -131,6 +132,7 @@ Head Paladin
 	ADD_TRAIT(H, TRAIT_LIFEGIVER,  REF(src))
 	ADD_TRAIT(H, TRAIT_IRONFIST,  REF(src))
 	H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
+	H.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
 
 /datum/outfit/job/bos/f13sentinel
 	name = "Paladin Commander"
@@ -370,6 +372,7 @@ Senior Paladin
 	ADD_TRAIT(H, TRAIT_PA_WEAR,  REF(src))
 	ADD_TRAIT(H, TRAIT_RESEARCHER,  REF(src))
 	H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
+	H.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
 
 /datum/outfit/job/bos/f13seniorpaladin
 	name =	"Senior Paladin"

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -175,6 +175,7 @@
 	ADD_TRAIT(H, TRAIT_ENCLAVE_CODES,  REF(src))
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ,  REF(src))
 	H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
+	H.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
 	H.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/marksmancarbine)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)

--- a/code/modules/spells/spell_types/terrifying_presence.dm
+++ b/code/modules/spells/spell_types/terrifying_presence.dm
@@ -42,3 +42,52 @@
 	for(var/mob/living/carbon/C in get_hearers_in_view(7, user))
 		if(!faction_check((user.faction - "neutral"), C.faction))
 			C.jitteriness += 5 // Scary, oooooo
+
+
+
+
+
+// Borrowed this idea from one of my other projects, gives leaders a way to actually mechanically be leaders. -Possum
+/obj/effect/proc_holder/spell/ferocious_loyalty
+	name = "Ferocious Loyalty"
+	desc = "Give the order of command, bolstering everyone around you by removing pain and healing minor wounds."
+	charge_max = 15 MINUTES // No spam
+	cooldown_min = 0
+	level_max = 1
+	clothes_req = NONE
+	antimagic_allowed = TRUE
+	action_icon = 'icons/mob/actions/actions_spells.dmi'
+	action_icon_state = "repulse"
+	var/message_said
+	var/list/span_list = list("ratvar")
+	var/speech_sound = 'sound/effects/bamf.ogg'
+
+/obj/effect/proc_holder/spell/ferocious_loyalty/can_cast(mob/living/user = usr, skipcharge = FALSE, silent = TRUE)
+	if(!user.can_speak())
+		if(!silent)
+			to_chat(user, "<span class='warning'>You are unable to speak!</span>")
+		return FALSE
+	if(!skipcharge && !charge_check(user, silent))
+		return FALSE
+	if(user.stat && !stat_allowed)
+		if(!silent)
+			to_chat(user, "<span class='notice'>Not when you're incapacitated.</span>")
+		return FALSE
+	return TRUE
+
+/obj/effect/proc_holder/spell/ferocious_loyalty/choose_targets(mob/living/user = usr)
+	perform(user=user)
+
+/obj/effect/proc_holder/spell/ferocious_loyalty/perform(list/targets, recharge = 1, mob/living/user = usr)
+	message_said = stripped_input(user, "What do you shout to inspire ferocious loyalty?", "Command")
+	if(!message_said)
+		revert_cast()
+		return
+	..()
+
+/obj/effect/proc_holder/spell/ferocious_loyalty/cast(list/targets, mob/living/user = usr)
+	user.say(message_said, spans = span_list, sanitize = FALSE)
+	playsound(get_turf(user), speech_sound, 100, 1, 5)
+	for(var/mob/living/carbon/C in get_hearers_in_view(7, user))
+		if(!faction_check((user.faction - "neutral"), C.faction))
+			C.reagents.add_reagent(/datum/reagent/medicine/ferocious_loyalty,30)


### PR DESCRIPTION
-Added a new perk called Ferocious Loyalty, which is applied to faction combat/squad leaders who had terrifying presence already (at present, I only updated leaders I know will remain pending the faction/map shift). So sheriff, enclave, and BoS leaders have this.
-Added a ferocious loyalty chem (which is added by the perk) under the name strange substance. This chem is added in a total of 30u by the ferocious loyalty perk to everyone who can hear you within 7 tiles after you say a custom golden text phrase that comes with a sound que and alert you've been buffed.
--You gain a slow passive heal roughly equal to 1/5th a stimpak that takes x3 as long to work.
--You gain +25 max health during the chems duration, similar to buff outs.
--You gain the trait perfect attacker (all punches deal 10 damage instead of random 1-10_.
--You ignore slowdown caused by damage.

Note: Ferocious loyalty has a 15 minute cooldown to prevent spamming and does not affect the person casting/shouting it, making it a squad booster only. Interesting to note, terrifying presence AND ferocious loyalty do a faction check, though I did not verify in testing, it might mean that raider players are immune to both shouts, for better or ill.

**Why put this in the game:**
Something that annoys me about pretty much all leadership roles in Fallout 13 is leaders are basically just x-job+ with better gear and perks, but otherwise are innately identical to regular joe smoes. This makes what should be a unique job practically meaningless, because anyone who either obtains your gear or finds something on par is basically equal to what is supposed to be a leader/squad commander. A fact that was/is compounded more by the fact that even additional perks that some leaders get are hampered by restrictions. Ergo, legion officers get great perks, but also get stimpak intolerance, brotherhood paladins get straight edge, etc. etc.. This weirdly enough means leader roles start off better and in the long wrong turn their unique qualities into a straight debuff.

So, I added this perk, a leader perk that does not benefit leaders in the slightest since they cannot gain the effects of their own shouts **BUT** everyone under their command does. A good long lasting set of passive effects you can use either before a fight or during (if you can type the right words fast enough) that keeps people in a better state while not hindering them in any way. This makes it so a leader actually has a reason their a leader, they can inspire people and keep them going.

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.