### PR TITLE
Hotfix

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -452,6 +452,7 @@
 /datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M)
 	if(M.blood_volume)
 		M.blood_volume += 0.1 // water is good for you!
+	M.adjustToxLoss(-0.1*REM, updating_health = FALSE)
 	if(!data)
 		data = list("misc" = 1)
 	data["misc"]++


### PR DESCRIPTION
-Holy water now properly heals toxins like regular water. Oversight caused by on_mob_life being overwritten, ran a test to verify and discovered the bug, now corrected.

