### PR TITLE
Cannibals, Renegades, and Loadouts! Oh my!

### DIFF
--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -146,8 +146,8 @@
 // LONGPORK STEW REAGENT
 
 /datum/reagent/medicine/longpork_stew
-	name = "Longpork stew"
-	description = "A dish sworn by some to have unusual healing properties. To most it just tastes disgusting. What even is longpork anyways?..."
+	name = "Longpork"
+	description = "A reagent sworn by some to have unusual healing properties. To most it just tastes disgusting. What even is longpork anyways?..."
 	reagent_state = LIQUID
 	color =  "#915818"
 	taste_description = "oily water, with bits of raw-tasting tender meat."

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -37,6 +37,8 @@
 	name = "meat"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/plain/human
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human
+	dried_type = /obj/item/reagent_containers/food/snacks/smokedpeople
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/cooking_oil = 2, /datum/reagent/medicine/longpork_stew = 1) // Gotta cook it to gt the real benefits
 	tastes = list("tender meat" = 1)
 	foodtype = MEAT | RAW | LONGPORK
 
@@ -419,6 +421,7 @@
 
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/plain/human
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/medicine/longpork_stew = 1)
 	tastes = list("tender meat" = 1)
 	foodtype = MEAT | RAW | LONGPORK
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -282,13 +282,6 @@
 	tastes = list("meat" = 3, "metal" = 1)
 	foodtype = MEAT
 
-/obj/item/reagent_containers/food/snacks/kebab/human
-	name = "human-kebab"
-	desc = "A human meat, on a stick."
-	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 6)
-	tastes = list("tender meat" = 3, "metal" = 1)
-	foodtype = MEAT | LONGPORK
-
 /obj/item/reagent_containers/food/snacks/kebab/monkey
 	name = "meat-kebab"
 	desc = "Delicious meat, on a stick."
@@ -528,3 +521,55 @@
 	list_reagents = list(/datum/reagent/consumable/eggyolk = 5)
 	tastes = list("dried eggs" = 1, "confusion" = 1)
 	dried_being = /mob/living/simple_animal/chicken
+
+// Cannibal snacks
+/obj/item/reagent_containers/food/snacks/kebab/human
+	name = "killer-kebab"
+	desc = "Meat that is good enough to kill for, on a stick."
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 6, /datum/reagent/medicine/longpork_stew = 5)
+	tastes = list("tender meat" = 3, "metal" = 1)
+	foodtype = MEAT | LONGPORK
+
+/obj/item/reagent_containers/food/snacks/pie/peoplepie
+	name = "prick-pie"
+	icon_state = "meatpie"
+	desc = "They probably deserved it for being such a prick!"
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/medicine/longpork_stew = 5)
+	tastes = list("pie" = 1, "meat" = 1)
+	foodtype = GRAIN | MEAT | LONGPORK
+
+/obj/item/reagent_containers/food/snacks/saltedpeople
+	name = "pernicious pemmican"
+	desc = "Slab of meat preserved in salt and tallow. Makes you thirsty."
+	icon_state = "meatsalted"
+	bitesize = 5
+	filling_color = "#800000"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/medicine/longpork_stew = 5)
+	tastes = list("meat" = 2, "salt" = 1)
+	foodtype = MEAT | LONGPORK
+
+/obj/item/reagent_containers/food/snacks/smokedpeople
+	name = "smoked sucker"
+	desc = "Slab of meat dried by smoking. Wait, this isn't sucker fish."
+	icon_state = "meatsmoked"
+	bitesize = 5
+	filling_color = "#800000"
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/medicine/longpork_stew = 5)
+	tastes = list("meat" = 2, "smoke" = 1)
+	foodtype = MEAT | LONGPORK
+
+/obj/item/reagent_containers/food/snacks/mcpersonnugget
+	name = "chicky nugget"
+	filling_color = "#B22222"
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1, , /datum/reagent/medicine/longpork_stew = 3)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
+	tastes = list("\"chicken\"" = 1)
+	foodtype = MEAT | LONGPORK
+
+/obj/item/reagent_containers/food/snacks/mcpersonnugget/Initialize(mapload)
+	. = ..()
+	var/shape = pick("lump", "star", "lizard", "corgi")
+	desc = "A 'chicky' nugget vaguely shaped like a [shape]. It certainly tastes like chicken..."
+	icon_state = "nugget_[shape]"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -39,15 +39,6 @@
 	result = /obj/item/reagent_containers/food/snacks/f13/deathclawomelette
 	subcategory = CAT_WASTEFOOD
 
-/datum/crafting_recipe/food/longpork_stew
-	name = "Longpork Stew"
-	reqs = list(/datum/reagent/water = 10, // must be before the bowl or else it'll runtime
-				/obj/item/reagent_containers/food/snacks/meat/slab/human= 1,
-				/obj/item/reagent_containers/glass/bowl = 1
-	)
-	result = /obj/item/reagent_containers/food/snacks/soup/longpork_stew
-	subcategory = CAT_WASTEFOOD
-
 /datum/crafting_recipe/food/moleratstew
 	name = "Molerat Stew"
 	reqs = list(
@@ -220,15 +211,6 @@
 //Sewer Food.  //
 /////////////////
 
-/datum/crafting_recipe/food/humankebab
-	name = "Human kebab"
-	reqs = list(
-		/obj/item/stack/rods = 1,
-		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 2
-	)
-	result = /obj/item/reagent_containers/food/snacks/kebab/human
-	subcategory = CAT_WASTEFOOD
-
 /datum/crafting_recipe/food/ratkebab
 	name = "Rat Kebab"
 	reqs = list(
@@ -245,4 +227,55 @@
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/rat
+	subcategory = CAT_WASTEFOOD
+
+
+/////////////////
+//Cannibal Food//
+/////////////////
+
+/datum/crafting_recipe/food/longpork_stew
+	name = "Longpork Stew"
+	reqs = list(/datum/reagent/water = 10, // must be before the bowl or else it'll runtime
+				/obj/item/reagent_containers/food/snacks/meat/slab/human= 1,
+				/obj/item/reagent_containers/glass/bowl = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/soup/longpork_stew
+	subcategory = CAT_WASTEFOOD
+
+/datum/crafting_recipe/food/humankebab
+	name = "Killer Kebab"
+	reqs = list(
+		/obj/item/stack/rods = 1,
+		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 2
+	)
+	result = /obj/item/reagent_containers/food/snacks/kebab/human
+	subcategory = CAT_WASTEFOOD
+
+/datum/crafting_recipe/food/peoplepie
+	name = "Prick-Pie"
+	reqs = list(
+		/datum/reagent/consumable/blackpepper = 1,
+		/datum/reagent/consumable/sodiumchloride = 1,
+		/obj/item/reagent_containers/food/snacks/pie/plain = 1,
+		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/pie/peoplepie
+	subcategory = CAT_WASTEFOOD
+
+/datum/crafting_recipe/food/saltedpeople
+	name = "Pernicious Pemmican"
+	reqs = list(
+		/datum/reagent/consumable/sodiumchloride = 1,
+		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/saltedpeople
+	subcategory = CAT_WASTEFOOD
+
+/datum/crafting_recipe/food/mcpersonnugget
+	name = "Chicky Nugget"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/mcpersonnugget
 	subcategory = CAT_WASTEFOOD

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -237,7 +237,7 @@
 /datum/crafting_recipe/food/longpork_stew
 	name = "Longpork Stew"
 	reqs = list(/datum/reagent/water = 10, // must be before the bowl or else it'll runtime
-				/obj/item/reagent_containers/food/snacks/meat/slab/human= 1,
+				/obj/item/reagent_containers/food/snacks/meat/slab/human = 1,
 				/obj/item/reagent_containers/glass/bowl = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/longpork_stew
@@ -258,7 +258,7 @@
 		/datum/reagent/consumable/blackpepper = 1,
 		/datum/reagent/consumable/sodiumchloride = 1,
 		/obj/item/reagent_containers/food/snacks/pie/plain = 1,
-		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 1
+		/obj/item/reagent_containers/food/snacks/meat/slab/human = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/peoplepie
 	subcategory = CAT_WASTEFOOD
@@ -267,7 +267,7 @@
 	name = "Pernicious Pemmican"
 	reqs = list(
 		/datum/reagent/consumable/sodiumchloride = 1,
-		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 1
+		/obj/item/reagent_containers/food/snacks/meat/slab/human = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/saltedpeople
 	subcategory = CAT_WASTEFOOD

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -76,7 +76,7 @@
 	neck = /obj/item/clothing/neck/apron/labor/forge/khan
 	belt = /obj/item/storage/belt/utility/artisan/full
 	glasses = /obj/item/clothing/glasses/welding
-	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/m1911=1)
+	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/m1911=1, /obj/item/ammo_box/magazine/m45 = 2, /obj/item/twohanded/sledgehammer/simple)
 
 /datum/outfit/loadout/scavenger
 	name = "Scavenger"
@@ -87,7 +87,8 @@
 	backpack_contents = list(/obj/item/mining_scanner=1,
 							/obj/item/metaldetector=1,
 							/obj/item/shovel=1,
-							/obj/item/gun/ballistic/automatic/pistol/m1911=1)
+							/obj/item/gun/ballistic/automatic/pistol/m1911=1,
+							/obj/item/ammo_box/magazine/m45 = 2)
 
 /datum/outfit/loadout/settler
 	name = "Settler"
@@ -104,6 +105,7 @@
 		/obj/item/cultivator = 1,
 		/obj/item/reagent_containers/glass/bucket = 1,
 		/obj/item/storage/bag/plants/portaseeder = 1,
+		/obj/item/ammo_box/magazine/m10mm = 2
 		)
 
 /datum/outfit/loadout/medic
@@ -118,6 +120,7 @@
 							/obj/item/smelling_salts=1,
 							/obj/item/healthanalyzer=1,
 							/obj/item/gun/ballistic/automatic/pistol/m1911=1,
+							/obj/item/ammo_box/magazine/m45 = 2,
 							/obj/item/reagent_containers/glass/bottle/epinephrine=2,
 							/obj/item/storage/backpack/duffelbag/med/surgery=1,
 							/obj/item/paper_bin=1,
@@ -136,7 +139,7 @@
 	glasses = /obj/item/clothing/glasses/f13/biker
 	l_hand = /obj/item/gun/ballistic/revolver/caravan_shotgun
 	backpack_contents =  list(/obj/item/storage/box/vendingmachine=1,
-							/obj/item/gun/ballistic/automatic/pistol/m1911=1)
+							/obj/item/gun/ballistic/automatic/pistol/m1911=1, /obj/item/ammo_box/magazine/m45 = 2, /obj/item/ammo_box/shotgun/buck = 2)
 
 /datum/outfit/loadout/vault_refugee
 	name = "Vaultie"
@@ -148,7 +151,7 @@
 	ears = /obj/item/radio/headset
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/ammo_box/magazine/m10mm=2,
+		/obj/item/ammo_box/magazine/m10mm=4,
 		/obj/item/pda=1,)
 
 /datum/outfit/loadout/warrior
@@ -186,7 +189,7 @@
 	id = /obj/item/card/id/dogtag/town/ncr
 	l_hand = /obj/item/gun/ballistic/rifle/mag/varmint
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m556mm=2)
+		/obj/item/ammo_box/magazine/m556mm=4)
 
 /datum/outfit/loadout/wastelander_desert_ranger
 	name = "Desert Cowboy"
@@ -198,4 +201,5 @@
 	backpack_contents = list(
 		/obj/item/ammo_box/a357=2,
 		/obj/item/binoculars=1,
-		/obj/item/radio=1)
+		/obj/item/radio=1,
+		/obj/item/melee/onehanded/knife/hunting=1)

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -97,6 +97,7 @@
 	icon_state = "handdrill"
 	item_state = "jackhammer"
 	slot_flags = ITEM_SLOT_BELT
+	force = 30 // It's a power drill that can cut through rocks.
 	toolspeed = 0.6 //available from roundstart, faster than a pickaxe.
 	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/f13/renegade.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/renegade.dm
@@ -270,6 +270,7 @@
 	retreat_distance = 3
 	minimum_distance = 1
 	ranged = 1
+	speed = 1.5
 	attack_verb_simple = "power-fists"
 	attack_sound = 'sound/weapons/slam.ogg'
 	ranged_cooldown_time = 30
@@ -348,6 +349,7 @@
 	projectiletype = /obj/item/projectile/bullet/a5mm/simple
 	health = 1250
 	maxHealth = 1250
+	speed = 1.5
 	melee_damage_upper = 50
 	minimum_distance = 0
 	obj_damage = 500

--- a/code/modules/mob/living/simple_animal/hostile/f13/renegade.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/renegade.dm
@@ -174,7 +174,7 @@
 /mob/living/simple_animal/hostile/renegade/defender/assaulter
 	name = "Renegade Assaulter"
 	desc = "The Renegade member who's sole purpose is to withstand punishment with layers of advanced combat armor- and dish out just as much with a well placed violent mace swing. As if to flaunt who's about to smack your skull in- there's a huge red R painted into his shield."
-	armour_penetration = 0.6
+	armour_penetration = 0.5
 	icon_state = "renegade_assaulter"
 	icon_living = "renegade_assaulter"
 	icon_dead = "renegade_assaulter-dead"
@@ -191,7 +191,7 @@
 	health = 280
 	healable = 1
 	speed = 1.3
-	vision_range = 12
+	//vision_range = 12
 	aggro_vision_range = 15
 	check_friendly_fire = 1
 	retreat_distance = 10
@@ -214,7 +214,7 @@
 	health = 300
 	maxHealth = 300
 	minimum_distance = 8
-	vision_range = 15
+	//vision_range = 15
 	icon_state = "renegade_sniper"
 	icon_living = "renegade_sniper"
 	icon_dead = "renegade_sniper-dead"
@@ -247,7 +247,7 @@
 /mob/living/simple_animal/hostile/renegade/guardian/shotgunner
 	name = "Renegade Shotgunner"
 	desc = "A veteran of the Renegades,specializing in close quarters and crowd control.. with an automatic full-metal burst-fire slug shotgun and advanced CQC training. Akin to certain gunners, this shotgunner has painted his shoulder-pads with red highlights."
-	armour_penetration = 5
+	armour_penetration = 0.3
 	extra_projectiles = 2
 	melee_queue_distance = 2
 	rapid_melee = 2
@@ -288,7 +288,7 @@
 	name = "Renegade Heavy"
 	desc = "Is that a merc in layered advanced combat armor, high on drugs?! Holy shit, that's a big gun!"
 	aggro_vision_range = 14
-	armour_penetration = 0.8
+	armour_penetration = 0.3
 	check_friendly_fire = 0
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	extra_projectiles = 7
@@ -339,12 +339,13 @@
 // THE BOSS. THE BIG ONE. THE BIG CHEESE
 /mob/living/simple_animal/hostile/raider/junker/boss/renegade
 	name = "Renegade Boss"
-	desc = "A Renegade boss, clad in hotrod power armor, and wielding a deadly rapid-fire shrapnel cannon. He's had enough of your shit."
+	desc = "A Renegade boss, clad in hotrod power armor, and wielding a deadly rapid-fire cannon. He's had enough of your shit."
 	faction = list("renegade")
 	aggro_vision_range = 15
-	armour_penetration = 0.8
+	armour_penetration = 0.3
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	extra_projectiles = 7
+	projectiletype = /obj/item/projectile/bullet/a5mm/simple
 	health = 1250
 	maxHealth = 1250
 	melee_damage_upper = 50
@@ -352,7 +353,7 @@
 	obj_damage = 500
 	rapid_melee = 2
 	retreat_distance = 0
-	vision_range = 15
+	//vision_range = 15
 	icon = 'icons/fallout/mobs/humans/renegade.dmi'
 	icon_state = "renegade_boss"
 	icon_living = "renegade_boss"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -9,7 +9,7 @@
 	health = 3000
 	maxHealth = 3000
 
-	armour_penetration = 0.7
+	armour_penetration = 0.3
 	melee_damage_lower = 40
 	melee_damage_upper = 50
 	vision_range = 9


### PR DESCRIPTION
**Cannibalism Additions**
-"Longpork stew" chemical reagent renamed to "Longpork" since it is in several recipes now.
-Human meat now has 1 reagent of longpork (chemical that heals cannibals) outright.
-Human meat now has a smoked meat path and becomes smoked sucker when properly smoked.
-Renamed human kebab to killer kebab and added the same base reagent bonus of longpork as longpork stew (it missing was an oversight)
-Added a variant of meat pie called prick pie, made from human meat.
-Added a variant of salted meat called pernicious pemmican, made from human meat.
-Added a recipe for chicky nuggets, which taste just like chicken and are made of human meat cutlets.

**Loadout Changes**
-All load outs save for legion citizen and wasteland wasteland warrior have been given 2 magazines to their preexisting range weapons and have been given a melee weapon if they did not have one prior. In some cases such as vaultie, ncr citizen, and merchant they were instead given 4 magazines instead of a melee weapon.
-Drill damage boosted to force 30 in place of a melee weapon for the scavenger loadout.

**Note**: Wasteland warrior was not changed because their unique armor is the best is class for melee protection light armor, while also getting a machete, shield, and grognaks, making them quite strong innately. Legion citizen was not changed for already having a good melee weapon and legion allies.

**NPC Balance Changes**
-Renegade mobs have had their armor pen lowered slightly, with melee specialist still clocking in at 0.5
-All renegade visions are now standard to raiders, but some retain their aggro vision range. This means that they can spot targets farther when looking for one, but passively should no longer aggro outside player vision range without a reason, such as taking damage. This should make sniper class enemies alot less awful AND should prevent certain renegade spawns from moving to weird locations and thus ambushing unprepared players as often.
-Fixed an over sight bug for the renegade shotgunner where he had armor pen 5, way beyond the limit of 1. Set to 0.3.
-Renegade heavy and renegade boss now have armor pen 0.3 since they have range attacks. Still super deadly to engage in melee since they have upper damage 50.
-Renegade boss now uses identical projectile type to the renegade heavy instead of scrap ammo, which is why he was melting people so fast with his gun.
-Renegade heavies and bosses now have speed 1.5, up from 1.2 (higher means slower).

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.