### PR TITLE
Random Fixes and QoL

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -295,11 +295,14 @@
 	lose_text = "<span class='danger'>You feel less healthy than usual.</span>"
 	//locked = TRUE
 
+// This somehow doesn't work and nobody fucking noticed, this means every job with Lifegiver dating back years
+// never got any bonus health and nobody noticed. Jesus christ I knew most ss13 coders were morons by this is special! -Possum
+/*
 /datum/quirk/lifegiver/on_spawn()
 	var/mob/living/carbon/human/mob_tar = quirk_holder
 	mob_tar.maxHealth += 10
 	mob_tar.health += 10
-
+*/
 /datum/quirk/iron_fist
 	name = "Iron Fist"
 	desc = "You have fists of kung-fury! Increases unarmed damage."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -365,11 +365,13 @@
 	gain_text = "<span class='notice'>You feel less healthy than usual.</span>"
 	lose_text = "<span class='danger'>You feel more healthy than usual.</span>"
 
+// Was originally mirrored from lifegiver, which turns out hasn't worked for literal *years*. Defining it elsewhere. -Possum
+/*
 /datum/quirk/lifeloser/on_spawn()
 	var/mob/living/carbon/human/mob_tar = quirk_holder
 	mob_tar.maxHealth -= 10
 	mob_tar.health -= 10
-
+*/
 /datum/quirk/paper_fist
 	name = "Paper Fist"
 	desc = "You have limp wrists and weak fists. You deal the alot less unarmed damage."

--- a/code/modules/fallout/obj/food_and_drinks/food.dm
+++ b/code/modules/fallout/obj/food_and_drinks/food.dm
@@ -245,7 +245,7 @@
 	name = "deathclaw steak"
 	desc = "A piece of hot spicy meat, eaten by only the most worthy hunters - or the most rich clients."
 	list_reagents = list(/datum/reagent/consumable/nutriment = 10)
-	bonus_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 10, /datum/reagent/medicine/tricordrazine = 8) 
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 10, /datum/reagent/medicine/tricordrazine = 8)
 
 /obj/item/reagent_containers/food/snacks/meat/steak/squirrel
 	name = "squirrel steak"
@@ -617,6 +617,20 @@
 	bonus_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 3, /datum/reagent/medicine/longpork_stew = 5)
 	filling_color = "#a7510b"
 	tastes = list("oily broth" = 5, "chewy meat" = 1)
+	foodtype = MEAT | LONGPORK
+	trash = /obj/item/reagent_containers/glass/bowl
+
+/obj/item/reagent_containers/food/snacks/soup/profane_stew
+	name = "profane stew"
+	desc = "A terrible stew made by someone clearly insane, its thick broth contains chunks of gooey and oily meat floating in an unholy mixture of bone broth, nukashine, and sliced sinew."
+	icon = 'icons/fallout/objects/food&drinks/soupsalad.dmi'
+	icon_state = "molerat_stew"
+	bitesize = 4
+	volume = 30
+	list_reagents = list(/datum/reagent/medicine/longpork_stew = 15, /datum/reagent/consumable/ethanol/nukashine = 15)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 3, /datum/reagent/medicine/longpork_stew = 5, /datum/reagent/consumable/ethanol/nukashine = 5)
+	filling_color = "#a7510b"
+	tastes = list("sweetness and liverpain" = 4, "chewy meat" = 1, "corruption" = 1)
 	foodtype = MEAT | LONGPORK
 	trash = /obj/item/reagent_containers/glass/bowl
 

--- a/code/modules/fallout/obj/manual/basic_advice.dm
+++ b/code/modules/fallout/obj/manual/basic_advice.dm
@@ -83,7 +83,7 @@
 
 				<h3>How to work a hammer and anvil and produce basic tools.</h3>
 
-				The needed tools are: good gloves, metal ingots, a furnace, wood planks, an anvil and a special hammer.
+				The needed tools are: good gloves, metal sheets, leather, a furnace, wood planks, an anvil and a special hammer.
 				<p>
 				<ol>
 				<li>Gloves: Not all gloves can handle red hot metal, Forgemaster gloves, or most others with fingers, or handwraps, are preferable. If you can move the hot metal from the furnace the gloves are good enough.</li>
@@ -129,10 +129,10 @@
 				<li>Sword: (FFDF) Fold, fold, draw, then FOLD SOME MORE. Done right, you get a proper sharp sword, after adding a sword handle.</li>
 				<li>Machete: (FDF) Fold the metal, draw it and ugh..yeah, fold it more. Add handle.</li>
 				<li>Heavy axe: (UDSP) Upset the hot metal, draw it, then shrink it and give it a solid punch. Add a wooden rod, then go chop down some wood or enemies. Easy. </li>
-				<li>Spear: (DDBF) Draw the metal twice, bend it and fold it. Add a rod, and enjoy a simple but effective weapon.</li>
+				<li>Spear: (DDBF) Draw the metal twice, bend it and fold it. Add a wood rod, and enjoy a simple but effective weapon.</li>
 				<li>Mace: (UPU) Upset, punch, upset. Now you have a properly blunt swinging stick.</li>
-				<li>Reforged Machete: (FDU) Fold it, draw it, and upset the metal. Some lesser anvils such as table anvils should make these instead of swords.</li>
-				<li>Scrap Blade: (UDSU) Upset, draw, shrink, upset. Lesser anvils such as table anvils should produce these in a proper axe.</li>
+				<li>Reforged Machete: (FDU) Fold it, draw it, and upset the metal.</li>
+				<li>Scrap Blade: (UDSU) Upset, draw, shrink, upset.</li>
 
 				<li>Throwing Weapons</li>
 				<li>Javelin: (DBF) Draw the metal, bend it and fold it, then add a wooden rod and throw it in someones face.</li>
@@ -145,7 +145,7 @@
 				<li>Lance: (DDBS) Draw, draw, bend, shrink and add a rod. Get a motorcycle to become wasteland cavalry. </li>
 				<li>Gladius: (DDP) Draw, draw, punch. Because regular swords are too small and not broad enough. Add a handle to finish.</li>
 				<li>Spatha: (FDUF) Fold, draw, upset, fold. You were too good for a gladius. Add a handle to finish.</li>
-				<li>Warhoned: (UDSB) Upset, draw, shrink, bend. You want to the biggest and best.</li>
+				<li>Warhoned: (UDSB) Upset, draw, shrink, bend. You want the biggest and best.</li>
 
 				<li>Armor and Clothing</li>
 				<li>Rings: (SSS) Tiny things, perhaps not of much use, but some will pay well for a ring made from the right material. Perhaps wearing it might just cheer you up.</li>

--- a/code/modules/fallout/reagents/alcohol.dm
+++ b/code/modules/fallout/reagents/alcohol.dm
@@ -236,6 +236,9 @@
 	glass_desc = "Nuka Cola with a alcoholic twist."
 
 /datum/reagent/consumable/ethanol/nukadark/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
@@ -254,6 +257,9 @@
 	ghoulfriendly = TRUE //too american for ghouls not to taste it
 
 /datum/reagent/consumable/ethanol/nukavictory/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	ADD_TRAIT(M, TRAIT_BIG_LEAGUES, "[type]")
 	M.adjustBruteLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.drowsyness = 0
@@ -284,6 +290,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	..()
 	. = TRUE
 
@@ -308,6 +317,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	..()
 	. = TRUE
 
@@ -329,6 +341,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	..()
 	. = TRUE
 
@@ -347,6 +362,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	..()
 	. = TRUE
 
@@ -371,6 +389,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	..()
 	. = TRUE
 
@@ -389,6 +410,9 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	..()
 	. = TRUE
 
@@ -465,6 +489,9 @@
 	M.AdjustKnockdown(-30, 0)
 	M.AdjustUnconscious(-30, 0)
 	M.adjustStaminaLoss(-5, updating_health = FALSE)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	ADD_TRAIT(M, TRAIT_IRONFIST, "[type]")
 	ADD_TRAIT(M, TRAIT_SLEEPIMMUNE, "[type]")
 	if(iscarbon(M))
@@ -793,6 +820,17 @@
 	glass_icon_state = "nukashine"
 	glass_name = "Nukashine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night. Stronger than the normal stuff, whooboy."
+
+/datum/reagent/consumable/ethanol/nukashine/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-3*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
+	M.drowsyness = 0
+	M.AdjustSleeping(-40, FALSE)
+	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
+	..()
+	. = TRUE
 
 /datum/reagent/consumable/ethanol/olflakey
 	name = "Ol' Flakey"

--- a/code/modules/fallout/reagents/drinks.dm
+++ b/code/modules/fallout/reagents/drinks.dm
@@ -147,6 +147,9 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukacherry/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjustFireLoss(-0.1*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
@@ -165,6 +168,9 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukagrape/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjustBruteLoss(-0.1*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
@@ -183,6 +189,9 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukaorange/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjustToxLoss(-0.1*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.drowsyness = 0
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
@@ -200,6 +209,9 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukaquartz/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjustOxyLoss(-1*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
@@ -218,6 +230,9 @@
 	water_level = 1.75
 
 /datum/reagent/consumable/nukaice/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT, T0C) //310.15 is the normal bodytemp.
 	M.drowsyness = 0
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
@@ -243,6 +258,9 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukawild/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.AdjustStun(-2, 0)
 	M.AdjustKnockdown(-2, 0)
 	M.drowsyness = 0
@@ -264,6 +282,9 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukanew/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.AdjustStun(-3, 0)
 	M.AdjustKnockdown(-3, 0)
@@ -283,6 +304,19 @@
 	glass_desc = "Nuka-Cola with a Berry Aftertaste."
 	water_level = 1.5
 
+/datum/reagent/consumable/nukaberry/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
+	M.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
+	M.AdjustStun(-3, 0)
+	M.AdjustKnockdown(-3, 0)
+	M.AdjustUnconscious(-3, 0)
+	M.drowsyness = 0
+	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	..()
+	. = TRUE
+
 /datum/reagent/consumable/nukacooler
 	name = "Nuka Cooler"
 	description = "Insanely cold Nuka-Cola, Freezing the air that surrounds it."
@@ -294,6 +328,9 @@
 	water_level = 1.85
 
 /datum/reagent/consumable/nukacooler/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjust_bodytemperature(-60 * TEMPERATURE_DAMAGE_COEFFICIENT, T0C) //310.15 is the normal bodytemp.
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
 	..()
@@ -310,6 +347,8 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukafree/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
 	if(M.nutrition <= NUTRITION_LEVEL_STARVING)
 		M.adjustToxLoss(0.1*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.nutrition = max(M.nutrition - 3, 0)
@@ -329,6 +368,8 @@
 	water_level = 1.5
 
 /datum/reagent/consumable/nukafrutti/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
 	M.adjustToxLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
 	M.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER, updating_health = FALSE)
@@ -348,6 +389,16 @@
 	glass_name = "Nuka Float"
 	glass_desc = "A delicious blend of ice-cream and classic Nuka-Cola!"
 	water_level = 1.5
+
+/datum/reagent/consumable/nukafloat/on_mob_life(mob/living/carbon/M)
+	M.drowsyness = 0
+	M.AdjustSleeping(-40, FALSE)
+	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
+		M.adjustBruteLoss(-0.05, updating_health = FALSE)
+		M.adjustFireLoss(-0.05, updating_health = FALSE)
+	..()
+	return TRUE // update health and mobility at end of tick
 
 /datum/reagent/consumable/sunsetfloat
 	name = "Sunset Float"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -243,10 +243,23 @@
 	result = /obj/item/reagent_containers/food/snacks/soup/longpork_stew
 	subcategory = CAT_WASTEFOOD
 
+/datum/crafting_recipe/food/profane_stew
+	name = "Profane Stew"
+	reqs = list(
+		/datum/reagent/consumable/ethanol/nukashine = 15,
+		/obj/item/reagent_containers/glass/bowl = 1,
+		/obj/item/stack/sheet/bone = 2,
+		/obj/item/stack/sheet/sinew = 2,
+		/obj/item/organ/tongue = 1,
+		/obj/item/organ/eyes = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/soup/profane_stew
+	subcategory = CAT_WASTEFOOD
+
 /datum/crafting_recipe/food/humankebab
 	name = "Killer Kebab"
 	reqs = list(
-		/obj/item/stack/rods = 1,
+		/obj/item/stack/sheet/bone = 1,
 		/obj/item/reagent_containers/food/snacks/meat/steak/plain/human = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/kebab/human

--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -437,6 +437,7 @@ Mayor
 		/obj/item/storage/belt/utility/artisan/full = 1,
 		/obj/item/clothing/glasses/welding = 1,
 		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/stack/sheet/metal/twenty = 1,
 		/obj/item/stack/sheet/mineral/sandstone/twenty = 1,
 		/obj/item/stack/sheet/mineral/titanium/fifteen = 1,
 		/obj/item/stack/sheet/mineral/wood = 10,
@@ -453,7 +454,8 @@ Mayor
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/storage/fancy/candle_box = 1,
 		/obj/item/pda = 1,
-		/obj/item/storage/bag/money/small/settler = 1
+		/obj/item/storage/bag/money/small/settler = 1,
+		/obj/item/book/manual/advice_blacksmith = 1
 	) // No weapons, you should be crafting them or using your null rod.
 
 // A preacher who brings god's enemies to the sword, a warrior of faith.

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -76,7 +76,7 @@
 	neck = /obj/item/clothing/neck/apron/labor/forge/khan
 	belt = /obj/item/storage/belt/utility/artisan/full
 	glasses = /obj/item/clothing/glasses/welding
-	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/m1911=1, /obj/item/ammo_box/magazine/m45 = 2, /obj/item/twohanded/sledgehammer/simple)
+	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/m1911=1, /obj/item/ammo_box/magazine/m45 = 2, /obj/item/twohanded/sledgehammer/simple = 1, /obj/item/book/manual/advice_blacksmith = 1)
 
 /datum/outfit/loadout/scavenger
 	name = "Scavenger"

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -8,6 +8,15 @@
 /mob/living/proc/Life(seconds, times_fired)
 	set waitfor = FALSE
 	if(!SPECIAL_SET)
+		// Lifegiver/Lifeloser was put here because the on_spawn proc was not working in traits, in theory this should only
+		// be called once at the same time endurance is checked. This does mean that admin spawned mobs wont run this proc, but if
+		// your admin spawning a player mob you can just edit the hp at that point. -Possum
+		if(HAS_TRAIT(src, TRAIT_LIFEGIVER))
+			src.maxHealth += 10
+			src.health += 10
+		if(HAS_TRAIT(src, TRAIT_LIFELOSER))
+			src.maxHealth -= 10
+			src.health -= 10
 		src.maxHealth += (src.special_e*3)//SPECIAL Integration
 		src.health += (src.special_e*3)//SPECIAL Integration
 		update_special_speed((5-src.special_a)/20)//SPECIAL Integration


### PR DESCRIPTION
-All nuka cola subtypes now count as nuka cola for the purposes of the nuka fiend healing perk.
-Added profane stew as a cannibal recipes that is sinew, bones, human tongue and eyes, and nukashine made into an unholy soup.
-Lifegiver now actually works, how nobody in F13 noticed it was broken for years is fucking amazing to me. Mirrored the fix to Lifeloser.
-The forgemaster primer now spawns in the inventory of forge priest and salvager wastelander. Also fixed some typos in it.

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.