### PR TITLE
More SPECIAL: Agility, Freerunning, More Traits

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -290,6 +290,7 @@
 
 // Negative Perks
 #define TRAIT_LIFELOSER			"lifeloser" // lowers HP
+#define TRAIT_BIG_LIFELOSER		"big_lifeloser" // lowers HP by alot
 #define TRAIT_PAPERFIST			"paper_fist" // weakens punches
 #define TRAIT_LITTLE_LEAGUES	"little_leagues" // less damage
 #define TRAIT_SHACKLEDRUNNING		"shackledrunning" // slow climbing

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -280,6 +280,9 @@
 #define TRAIT_STIM_INTOLERANCE	"stim_intolerance" //Stims cause vomiting, make you jittery, dizzy and confused
 #define TRAIT_STRAIGHT_EDGE		"straight_edge"	//Fallout chems like Med-X, Psycho, Jet, Turbo etc. cause vomiting, make you jittery, dizzy and confused
 #define TRAIT_HERBAL_AFFINITY	"herbal_affinity"	//Improved tribal medicine healing rates and no drawbacks (no confusion, hallucinations, dizziness etc.)
+#define TRAIT_LEAPER_WEAK		"leaper_weak" // leap 4 tiles
+#define TRAIT_LEAPER_MODERATE	"leaper_moderate" // leap 7 tiles
+#define TRAIT_LEAPER_STRONG		"leaper_strong" // leap 7 styles and stun people you hit
 
 #define TRAIT_SURGERY_LOW		"lowsurgery"
 #define TRAIT_SURGERY_MID		"midsurgery"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -282,7 +282,7 @@
 #define TRAIT_HERBAL_AFFINITY	"herbal_affinity"	//Improved tribal medicine healing rates and no drawbacks (no confusion, hallucinations, dizziness etc.)
 #define TRAIT_LEAPER_WEAK		"leaper_weak" // leap 4 tiles
 #define TRAIT_LEAPER_MODERATE	"leaper_moderate" // leap 7 tiles
-#define TRAIT_LEAPER_STRONG		"leaper_strong" // leap 7 styles and stun people you hit
+#define TRAIT_LEAPER_STRONG		"leaper_strong" // leap 5 tiles and stun people you hit
 
 #define TRAIT_SURGERY_LOW		"lowsurgery"
 #define TRAIT_SURGERY_MID		"midsurgery"

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -28,14 +28,16 @@
 	var/min_distance
 	///The throwdatum we're currently dealing with, if we need it
 	var/datum/thrownthing/tackle
-	//Bonus damage
-	var/bonus_damage = 0
+	/// Is it just a simple dive-kick?
+	var/simple_dunk
+	// is it just a STRONG simple dive-kick?
+	var/simple_dunkstrong
 
 /datum/component/tackler/weak
-	bonus_damage = 5
+	simple_dunk = TRUE
 
 /datum/component/tackler/strong
-	bonus_damage = 20
+	simple_dunkstrong = TRUE
 
 /datum/component/tackler/Initialize(stamina_cost = 25, base_knockdown = 1 SECONDS, range = 4, speed = 1, skill_mod = 0, min_distance = min_distance)
 	if(!iscarbon(parent))
@@ -49,15 +51,14 @@
 	src.min_distance = min_distance
 
 	var/mob/living/carbon/P = parent
-	to_chat(P, "<span class='notice'>You are now able to launch tackles! You can do so by activating throw intent, and clicking on your target with an empty hand.</span>")
-	P.tackling = TRUE
-	addtimer(CALLBACK(src, .proc/resetTackle), base_knockdown, TIMER_STOPPABLE)
+	to_chat(P, span_notice("You are now able to launch tackles! You can do so by activating throw intent, and clicking on your target with an empty hand."))
+	addtimer(CALLBACK(src, .proc/resetTackle), max(base_knockdown, 3 SECONDS), TIMER_STOPPABLE)
 
 /datum/component/tackler/Destroy()
 	var/mob/living/carbon/P = parent
-	to_chat(P, "<span class='notice'>You can no longer tackle.</span>")
+	to_chat(P, span_notice("You can no longer tackle."))
 	P.tackling = FALSE
-	return ..()
+	..()
 
 /datum/component/tackler/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_MOB_CLICKON, .proc/checkTackle)
@@ -78,23 +79,23 @@
 		return
 
 	if(HAS_TRAIT(user, TRAIT_HULK))
-		to_chat(user, "<span class='warning'>You're too angry to remember how to tackle!</span>")
+		to_chat(user, span_warning("You're too angry to remember how to tackle!"))
 		return
 
 	if(user.restrained())
-		to_chat(user, "<span class='warning'>You need free use of your hands to tackle!</span>")
+		to_chat(user, span_warning("You need free use of your hands to tackle!"))
 		return
 
 	if(!(user.mobility_flags & MOBILITY_STAND))
-		to_chat(user, "<span class='warning'>You must be standing to tackle!</span>")
+		to_chat(user, span_warning("You must be standing to tackle!"))
 		return
 
 	if(user.tackling)
-		to_chat(user, "<span class='warning'>You're not ready to tackle!</span>")
+		to_chat(user, span_warning("You're not ready to tackle!"))
 		return
 
 	if(user.has_status_effect(STATUS_EFFECT_TASED)) // can't tackle if you just got tased
-		to_chat(user, "<span class='warning'>You can't tackle while tased!</span>")
+		to_chat(user, span_warning("You can't tackle while tased!"))
 		return
 
 	user.face_atom(A)
@@ -104,23 +105,24 @@
 		return
 
 	user.tackling = TRUE
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/checkObstacle)
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/checkObstacle, TRUE)
 	playsound(user, 'sound/weapons/thudswoosh.ogg', 40, TRUE, -1)
 
 	var/leap_word = iscatperson(user) ? "pounce" : "leap" ///If cat, "pounce" instead of "leap".
 	if(can_see(user, A, 7))
-		user.visible_message("<span class='warning'>[user] [leap_word]s at [A]!</span>", "<span class='danger'>You [leap_word] at [A]!</span>")
+		user.visible_message(span_warning("[user] [leap_word]s at [A]!"), span_danger("You [leap_word] at [A]!"))
 	else
-		user.visible_message("<span class='warning'>[user] [leap_word]s!</span>", "<span class='danger'>You [leap_word]!</span>")
+		user.visible_message(span_warning("[user] [leap_word]s!"), span_danger("You [leap_word]!"))
 
 	if(get_dist(user, A) < min_distance)
 		A = get_ranged_target_turf(user, get_dir(user, A), min_distance) //TODO: this only works in cardinals/diagonals, make it work with in-betweens too!
 
-	user.Knockdown(base_knockdown, TRUE, TRUE)
+	if(base_knockdown)
+		user.Knockdown(base_knockdown, TRUE, TRUE)
 	user.adjustStaminaLoss(stamina_cost)
-	user.throw_at(A, range, speed, user, FALSE)
+	user.throw_at(A, range, speed, user, TRUE)
 	user.toggle_throw_mode()
-	addtimer(CALLBACK(src, .proc/resetTackle), base_knockdown, TIMER_STOPPABLE)
+	addtimer(CALLBACK(src, .proc/resetTackle), max(base_knockdown, 3 SECONDS), TIMER_STOPPABLE)
 	return(COMSIG_MOB_CANCEL_CLICKON)
 
 /**
@@ -147,6 +149,14 @@
 	if(!user.tackling || !tackle)
 		return
 
+	if(simple_dunk && isliving(hit))
+		simple_sack(user, hit)
+		return
+
+	if(simple_dunkstrong && isliving(hit))
+		simple_sackstrong(user, hit)
+		return
+
 	if(!iscarbon(hit))
 		if(hit.density)
 			return splat(user, hit)
@@ -160,8 +170,8 @@
 
 	switch(roll)
 		if(-INFINITY to -5)
-			user.visible_message("<span class='danger'>[user] botches [user.p_their()] [tackle_word] and slams [user.p_their()] head into [target], knocking [user.p_them()]self silly!</span>", "<span class='userdanger'>You botch your [tackle_word] and slam your head into [target], knocking yourself silly!</span>", target)
-			to_chat(target, "<span class='userdanger'>[user] botches [user.p_their()] [tackle_word] and slams [user.p_their()] head into you, knocking [user.p_them()]self silly!</span>")
+			user.visible_message(span_danger("[user] botches [user.p_their()] [tackle_word] and slams [user.p_their()] head into [target], knocking [user.p_them()]self silly!"), span_userdanger("You botch your [tackle_word] and slam your head into [target], knocking yourself silly!"), target)
+			to_chat(target, span_userdanger("[user] botches [user.p_their()] [tackle_word] and slams [user.p_their()] head into you, knocking [user.p_them()]self silly!"))
 
 			user.Paralyze(30)
 			var/obj/item/bodypart/head/hed = user.get_bodypart(BODY_ZONE_HEAD)
@@ -170,39 +180,37 @@
 			user.gain_trauma(/datum/brain_trauma/mild/concussion)
 
 		if(-4 to -2) // glancing blow at best
-			user.visible_message("<span class='warning'>[user] lands a weak [tackle_word] on [target], briefly knocking [target.p_them()] off-balance!</span>", "<span class='userdanger'>You land a weak [tackle_word] on [target], briefly knocking [target.p_them()] off-balance!</span>", target)
-			to_chat(target, "<span class='userdanger'>[user] lands a weak [tackle_word] on you, briefly knocking you off-balance!</span>")
+			user.visible_message(span_warning("[user] lands a weak [tackle_word] on [target], briefly knocking [target.p_them()] off-balance!"), span_userdanger("You land a weak [tackle_word] on [target], briefly knocking [target.p_them()] off-balance!"), target)
+			to_chat(target, span_userdanger("[user] lands a weak [tackle_word] on you, briefly knocking you off-balance!"))
 			user.Knockdown(30)
 			target.adjustStaminaLoss(15)
 			target.apply_status_effect(STATUS_EFFECT_TASED_WEAK, 6 SECONDS)
 
 		if(-1 to 0) // decent hit, both parties are about equally inconvenienced
-			user.visible_message("<span class='warning'>[user] lands a passable [tackle_word] on [target], sending them both tumbling!</span>", "<span class='userdanger'>You land a passable [tackle_word] on [target], sending you both tumbling!</span>", target)
-			to_chat(target, "<span class='userdanger'>[user] lands a passable [tackle_word] on you, sending you both tumbling!</span>")
+			user.visible_message(span_warning("[user] lands a passable [tackle_word] on [target], sending them both tumbling!"), span_userdanger("You land a passable [tackle_word] on [target], sending you both tumbling!"), target)
+			to_chat(target, span_userdanger("[user] lands a passable [tackle_word] on you, sending you both tumbling!"))
 
-			target.adjustBruteLoss(5 + bonus_damage)
 			target.adjustStaminaLoss(stamina_cost * 1.5)
 			target.Paralyze(5)
 			user.Knockdown(20)
 			target.Knockdown(30)
 
 		if(1 to 2) // solid hit, tackler has a slight advantage
-			user.visible_message("<span class='warning'>[user] lands a solid [tackle_word] on [target], knocking them both down hard!</span>", "<span class='userdanger'>You land a solid [tackle_word] on [target], knocking you both down hard!</span>", target)
-			to_chat(target, "<span class='userdanger'>[user] lands a solid [tackle_word] on you, knocking you both down hard!</span>")
-			target.adjustBruteLoss(10 + bonus_damage)
+			user.visible_message(span_warning("[user] lands a solid [tackle_word] on [target], knocking them both down hard!"), span_userdanger("You land a solid [tackle_word] on [target], knocking you both down hard!"), target)
+			to_chat(target, span_userdanger("[user] lands a solid [tackle_word] on you, knocking you both down hard!"))
+
 			target.adjustStaminaLoss(40)
 			target.Paralyze(5)
 			user.Knockdown(10)
 			target.Knockdown(20)
 
 		if(3 to 4) // really good hit, the target is definitely worse off here. Without positive modifiers, this is as good a tackle as you can land
-			user.visible_message("<span class='warning'>[user] lands an expert [tackle_word] on [target], knocking [target.p_them()] down hard while landing on [user.p_their()] feet with a passive grip!</span>", "<span class='userdanger'>You land an expert [tackle_word] on [target], knocking [target.p_them()] down hard while landing on your feet with a passive grip!</span>", target)
-			to_chat(target, "<span class='userdanger'>[user] lands an expert [tackle_word] on you, knocking you down hard and maintaining a passive grab!</span>")
+			user.visible_message(span_warning("[user] lands an expert [tackle_word] on [target], knocking [target.p_them()] down hard while landing on [user.p_their()] feet with a passive grip!"), span_userdanger("You land an expert [tackle_word] on [target], knocking [target.p_them()] down hard while landing on your feet with a passive grip!"), target)
+			to_chat(target, span_userdanger("[user] lands an expert [tackle_word] on you, knocking you down hard and maintaining a passive grab!"))
 
 			user.SetKnockdown(0)
 			user.set_resting(FALSE, TRUE, FALSE)
 			user.forceMove(get_turf(target))
-			target.adjustBruteLoss(20 + bonus_damage)
 			target.adjustStaminaLoss(50)
 			target.Paralyze(3) //Otherwise the victim can just instantly get out of the grab.
 			target.DefaultCombatKnockdown(20) //So they cant get up instantly.
@@ -210,13 +218,12 @@
 				target.grabbedby(user)
 
 		if(5 to INFINITY) // absolutely BODIED
-			user.visible_message("<span class='warning'>[user] lands a monster [tackle_word] on [target], knocking [target.p_them()] senseless and applying an aggressive pin!</span>", "<span class='userdanger'>You land a monster [tackle_word] on [target], knocking [target.p_them()] senseless and applying an aggressive pin!</span>", target)
-			to_chat(target, "<span class='userdanger'>[user] lands a monster [tackle_word] on you, knocking you senseless and aggressively pinning you!</span>")
+			user.visible_message(span_warning("[user] lands a monster [tackle_word] on [target], knocking [target.p_them()] senseless and applying an aggressive pin!"), span_userdanger("You land a monster [tackle_word] on [target], knocking [target.p_them()] senseless and applying an aggressive pin!"), target)
+			to_chat(target, span_userdanger("[user] lands a monster [tackle_word] on you, knocking you senseless and aggressively pinning you!"))
 
 			user.SetKnockdown(0)
 			user.set_resting(FALSE, TRUE, FALSE)
 			user.forceMove(get_turf(target))
-			target.adjustBruteLoss(30 + bonus_damage)
 			target.adjustStaminaLoss(65)
 			target.Paralyze(10)
 			target.DefaultCombatKnockdown(20)
@@ -225,6 +232,141 @@
 				target.grippedby(user, instant = TRUE)
 
 	SEND_SIGNAL(user, COMSIG_CARBON_TACKLED, roll)
+	return COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH
+
+/**
+ * rollTackle()
+ *
+ * This handles all of the modifiers for the actual carbon-on-carbon tackling, and gets its own proc because of how many there are (with plenty more in mind!)
+ *
+ * The base roll is between (-3, 3), with negative numbers favoring the target, and positive numbers favoring the tackler. The target and the tackler are both assessed for
+ *	how easy they are to knock over, with clumsiness and dwarfiness being strong maluses for each, and gigantism giving a bonus for each. These numbers and ideas
+ *	are absolutely subject to change.
+
+ * In addition, after subtracting the defender's mod and adding the attacker's mod to the roll, the component's base (skill) mod is added as well. Some sources of tackles
+ *	are better at taking people down, like the bruiser and rocket gloves, while the dolphin gloves have a malus in exchange for better mobility.
+*/
+/datum/component/tackler/proc/simple_sack(mob/living/carbon/user, mob/living/hit)
+	if(!iscarbon(user) || !isliving(hit))
+		return
+
+	var/roll = iscarbon(hit) ? rollTackle(hit) : 5 // extra damage to simplemobs
+	user.tackling = FALSE
+
+	var/tackle_damage = user.special_s
+	if(HAS_TRAIT(user, TRAIT_IRONFIST))
+		tackle_damage += 6
+	var/damage_mod = 1
+
+	switch(roll)
+		if(-INFINITY to -5)
+			damage_mod *= 0.5
+		if(-4 to -2)
+			damage_mod *= 0.8
+		if(2 to 3)
+			damage_mod *= 1.2
+		if(4 to INFINITY)
+			damage_mod *= 1.5
+
+	if(tackle?.dist_travelled)
+		damage_mod *= (1 + (0.5*tackle.dist_travelled))
+
+	switch(damage_mod)
+		if(-INFINITY to 1)
+			user.visible_message(
+				span_warning("[user] rams into [hit] with a flying tackle!"),
+				span_userdanger("You rams into [hit] with a flying tackle!"),
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] rams into you!"))
+		if(1.1 to 3)
+			user.visible_message(
+				span_warning("[user] slams into [hit] with a deadly charge!"),
+				span_userdanger("You slam into [hit] with a deadly charge!"),
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] slams into you!"))
+		if(3.1 to INFINITY)
+			user.visible_message(
+				span_warning("[user] CRASHES into [hit] with an atomic clothesline!"),
+				span_userdanger("You CRASH into [hit] with a atomic clothesline!"),
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] CRASHES into you!"))
+	playsound(user, 'sound/weapons/smash.ogg', 70, TRUE)
+	if(damage_mod >= 2)
+		hit.emote("scream")
+	user.emote("scream")
+
+	var/armormult = clamp(hit.getarmor(BODY_ZONE_CHEST, "melee"), 0, 1)
+
+	hit.apply_damage(tackle_damage, STAMINA, BODY_ZONE_CHEST, armormult)
+	hit.apply_damage(tackle_damage, BRUTE, BODY_ZONE_CHEST, armormult)
+	if(hit.anchored)
+		return
+	var/atom/throw_target = get_ranged_target_turf(hit, get_dir(user, hit), rand(CEILING(damage_mod * 0.5, 1), CEILING(damage_mod, 1)), 2)
+	hit.safe_throw_at(throw_target, 10, 1, user, TRUE)
+
+	SEND_SIGNAL(user, COMSIG_CARBON_TACKLED, CEILING(damage_mod, 1))
+	return COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH
+
+//crappy "strong" version of the simple dunk, meant for high tier quirks and raging boar.
+/datum/component/tackler/proc/simple_sackstrong(mob/living/carbon/user, mob/living/hit)
+	if(!iscarbon(user) || !isliving(hit))
+		return
+
+	var/roll = iscarbon(hit) ? rollTackle(hit) : 10 // extra damage to simplemobs (For some reason it's less than it seems)
+	user.tackling = FALSE
+
+	var/tackle_damage = user.special_s * 3
+	if(HAS_TRAIT(user, TRAIT_IRONFIST))
+		tackle_damage += 12
+	var/damage_mod = 1
+
+	switch(roll)
+		if(-INFINITY to -5)
+			damage_mod *= 0.5
+		if(-4 to -2)
+			damage_mod *= 0.8
+		if(2 to 3)
+			damage_mod *= 1.5
+		if(4 to INFINITY)
+			damage_mod *= 2
+
+	if(tackle?.dist_travelled)
+		damage_mod *= (1.5 + (2*tackle.dist_travelled))
+
+	switch(damage_mod)
+		if(-INFINITY to 1)
+			user.visible_message(
+				span_warning("[user] rams into [hit] with a flying tackle!"),
+				span_userdanger("You rams into [hit] with a flying tackle!"),
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] rams into you!"))
+		if(1.1 to 3)
+			user.visible_message(
+				span_warning("[user] slams into [hit] with a deadly charge!"),
+				span_userdanger("You slam into [hit] with a deadly charge!"),
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] slams into you!"))
+		if(3.1 to INFINITY)
+			user.visible_message(
+				span_warning("[user] CRASHES into [hit] with an powerful dropkick!"),
+				span_userdanger("You CRASH into [hit] with a powerful dropkick!"),
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] CRASHES into you!"))
+	playsound(user, 'sound/weapons/smash.ogg', 70, TRUE)
+	if(damage_mod >= 2)
+		hit.emote("scream")
+	user.emote("scream")
+
+	var/armormult = clamp(hit.getarmor(BODY_ZONE_CHEST, "melee"), 0, 1)
+
+	hit.apply_damage(tackle_damage, STAMINA, BODY_ZONE_CHEST, armormult)
+	hit.apply_damage(tackle_damage, BRUTE, BODY_ZONE_CHEST, armormult)
+	if(hit.anchored)
+		return
+	var/atom/throw_target = get_ranged_target_turf(hit, get_dir(user, hit), rand(CEILING(damage_mod * 0.5, 1), CEILING(damage_mod, 3)), 2)
+	hit.throw_at(throw_target, 10, 1, user, TRUE)
+
+	SEND_SIGNAL(user, COMSIG_CARBON_TACKLED, CEILING(damage_mod, 1))
 	return COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH
 
 /**
@@ -296,7 +438,7 @@
 		var/mob/living/carbon/human/S = sacker
 
 		var/suit_slot = S.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(suit_slot && (istype(suit_slot,/obj/item/clothing/suit/armor/riot))) // tackling in riot armor is more effective, but tiring
+		if(suit_slot && (istype(suit_slot,/obj/item/clothing/suit/armored/heavy))) // tackling in riot armor is more effective, but tiring
 			attack_mod += 2
 			sacker.adjustStaminaLoss(20)
 
@@ -354,36 +496,33 @@
 
 	var/oopsie = rand(danger_zone, 100)
 	if(oopsie >= 94 && oopsie_mod < 0) // good job avoiding getting paralyzed! gold star!
-		to_chat(user, "<span class='usernotice'>You're really glad you're wearing protection!</span>")
+		to_chat(user, span_notice("You're really glad you're wearing protection!"))
 	oopsie += oopsie_mod
 
 	switch(oopsie)
 		if(99 to INFINITY)
-			// can you imagine standing around minding your own business when all of the sudden some guy fucking launches himself into a wall at full speed and irreparably paralyzes himself?
-			user.visible_message("<span class='danger'>[user] slams face-first into [hit] at an awkward angle, severing [user.p_their()] spinal column with a sickening crack! Holy shit!</span>", "<span class='userdanger'>You slam face-first into [hit] at an awkward angle, severing your spinal column with a sickening crack! Holy shit!</span>")
+			user.visible_message(span_danger("[user] slams face-first into [hit] at an awkward angle! Holy shit!"), span_userdanger("You slam face-first into [hit] at an awkward angle! Holy shit!"))
 			user.adjustStaminaLoss(30)
-			user.adjustBruteLoss(30)
+			user.adjustBruteLoss(80)
+			user.Unconscious(100)
+			user.gain_trauma_type(BRAIN_TRAUMA_MILD)
 			playsound(user, 'sound/effects/blobattack.ogg', 60, TRUE)
 			playsound(user, 'sound/effects/splat.ogg', 70, TRUE)
-			user.emote("scream")
-			user.gain_trauma(/datum/brain_trauma/severe/paralysis/spinesnapped) // oopsie indeed!
-			shake_camera(user, 7, 7)
-			user.overlay_fullscreen("flash", /atom/movable/screen/fullscreen/flash)
-			user.clear_fullscreen("flash", 4.5)
+			user.playsound_local(get_turf(user), 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 
 		if(94 to 98)
-			user.visible_message("<span class='danger'>[user] slams face-first into [hit] with a concerning squish, immediately going limp!</span>", "<span class='userdanger'>You slam face-first into [hit], and immediately lose consciousness!</span>")
+			user.visible_message(span_danger("[user] slams face-first into [hit] with a concerning squish, immediately going limp!"), span_userdanger("You slam face-first into [hit], and immediately lose consciousness!"))
 			user.adjustStaminaLoss(100)
 			user.adjustBruteLoss(30)
 			user.Unconscious(100)
 			user.gain_trauma_type(BRAIN_TRAUMA_MILD)
 			user.playsound_local(get_turf(user), 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 			shake_camera(user, 6, 6)
-			user.overlay_fullscreen("flash", /atom/movable/screen/fullscreen/flash)
-			user.clear_fullscreen("flash", 3.5)
+			//user.overlay_fullscreen("flash", /obj/screen/fullscreen/flash)
+			//user.clear_fullscreen("flash", 3.5)
 
 		if(84 to 93)
-			user.visible_message("<span class='danger'>[user] slams head-first into [hit], suffering major cranial trauma!</span>", "<span class='userdanger'>You slam head-first into [hit], and the world explodes around you!</span>")
+			user.visible_message(span_danger("[user] slams head-first into [hit], suffering major cranial trauma!"), span_userdanger("You slam head-first into [hit], and the world explodes around you!"))
 			user.adjustStaminaLoss(30)
 			user.adjustBruteLoss(30)
 			user.confused += 15
@@ -392,11 +531,11 @@
 			user.playsound_local(get_turf(user), 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 			user.DefaultCombatKnockdown(40)
 			shake_camera(user, 5, 5)
-			user.overlay_fullscreen("flash", /atom/movable/screen/fullscreen/flash)
-			user.clear_fullscreen("flash", 2.5)
+			//user.overlay_fullscreen("flash", /obj/screen/fullscreen/flash)
+			//user.clear_fullscreen("flash", 2.5)
 
 		if(64 to 83)
-			user.visible_message("<span class='danger'>[user] slams hard into [hit], knocking [user.p_them()] senseless!</span>", "<span class='userdanger'>You slam hard into [hit], knocking yourself senseless!</span>")
+			user.visible_message(span_danger("[user] slams hard into [hit], knocking [user.p_them()] senseless!"), span_userdanger("You slam hard into [hit], knocking yourself senseless!"))
 			user.adjustStaminaLoss(30)
 			user.adjustBruteLoss(10)
 			user.confused += 10
@@ -404,7 +543,7 @@
 			shake_camera(user, 3, 4)
 
 		if(1 to 63)
-			user.visible_message("<span class='danger'>[user] slams into [hit]!</span>", "<span class='userdanger'>You slam into [hit]!</span>")
+			user.visible_message(span_danger("[user] slams into [hit]!"), span_userdanger("You slam into [hit]!"))
 			user.adjustStaminaLoss(20)
 			user.adjustBruteLoss(10)
 			user.DefaultCombatKnockdown(30)
@@ -416,6 +555,7 @@
 /datum/component/tackler/proc/resetTackle()
 	var/mob/living/carbon/P = parent
 	P.tackling = FALSE
+	to_chat(P, span_green("You can tackle again!"))
 	QDEL_NULL(tackle)
 	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
 
@@ -435,13 +575,13 @@
 		user.adjustStaminaLoss(10 * speed)
 		user.DefaultCombatKnockdown(40)
 		user.Paralyze(5)
-		user.visible_message("<span class='danger'>[user] slams into [W] and shatters it, shredding [user.p_them()]self with glass!</span>", "<span class='userdanger'>You slam into [W] and shatter it, shredding yourself with glass!</span>")
+		user.visible_message(span_danger("[user] slams into [W] and shatters it, shredding [user.p_them()]self with glass!"), span_userdanger("You slam into [W] and shatter it, shredding yourself with glass!"))
 
 	else
-		user.visible_message("<span class='danger'>[user] slams into [W] like a bug, then slowly slides off it!</span>", "<span class='userdanger'>You slam into [W] like a bug, then slowly slide off it!</span>")
+		user.visible_message(span_danger("[user] slams into [W] like a bug, then slowly slides off it!"), span_userdanger("You slam into [W] like a bug, then slowly slide off it!"))
 		user.Paralyze(2)
 		user.DefaultCombatKnockdown(20)
-		W.take_damage(20 * speed)
+		W.take_damage(20 * speed, attacked_by = user)
 		user.adjustStaminaLoss(10 * speed)
 		user.adjustBruteLoss(5 * speed)
 
@@ -482,7 +622,7 @@
 		else
 			HOW_big_of_a_miss_did_we_just_make = ", making a ginormous mess!" // an extra exclamation point!! for emphasis!!!
 
-	owner.visible_message("<span class='danger'>[owner] trips over [kevved] and slams into it face-first[HOW_big_of_a_miss_did_we_just_make]!</span>", "<span class='userdanger'>You trip over [kevved] and slam into it face-first[HOW_big_of_a_miss_did_we_just_make]!</span>")
+	owner.visible_message(span_danger("[owner] trips over [kevved] and slams into it face-first[HOW_big_of_a_miss_did_we_just_make]!"), span_userdanger("You trip over [kevved] and slam into it face-first[HOW_big_of_a_miss_did_we_just_make]!"))
 	owner.adjustStaminaLoss(20 + messes.len * 2)
 	owner.adjustBruteLoss(10 + messes.len)
 	owner.Paralyze(2 * messes.len)
@@ -494,7 +634,7 @@
 		if(prob(25 * (src.speed - 1))) // if our tackle speed is higher than 1, with chance (speed - 1 * 25%), throw the thing at our tackle speed + 1
 			sp = speed + 1
 		I.throw_at(get_ranged_target_turf(I, pick(GLOB.alldirs), range = dist), range = dist, speed = sp)
-		I.visible_message("<span class='danger'>[I] goes flying[sp > 3 ? " dangerously fast" : ""]!</span>") // standard embed speed
+		I.visible_message(span_danger("[I] goes flying[sp > 3 ? " dangerously fast" : ""]!")) // standard embed speed
 
 	playsound(owner, 'sound/weapons/smash.ogg', 70, TRUE)
 	tackle.finalize(hit=TRUE)

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -28,6 +28,14 @@
 	var/min_distance
 	///The throwdatum we're currently dealing with, if we need it
 	var/datum/thrownthing/tackle
+	//Bonus damage
+	var/bonus_damage = 0
+
+/datum/component/tackler/weak
+	bonus_damage = 5
+
+/datum/component/tackler/strong
+	bonus_damage = 20
 
 /datum/component/tackler/Initialize(stamina_cost = 25, base_knockdown = 1 SECONDS, range = 4, speed = 1, skill_mod = 0, min_distance = min_distance)
 	if(!iscarbon(parent))
@@ -289,7 +297,7 @@
 			attack_mod += 2
 			sacker.adjustStaminaLoss(20)
 
-	var/r = rand(-3, 3) - defense_mod + attack_mod + skill_mod
+	var/r = rand(-3, 3) - defense_mod + attack_mod + skill_mod + bonus_damage
 	return r
 
 

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -180,6 +180,7 @@
 			user.visible_message("<span class='warning'>[user] lands a passable [tackle_word] on [target], sending them both tumbling!</span>", "<span class='userdanger'>You land a passable [tackle_word] on [target], sending you both tumbling!</span>", target)
 			to_chat(target, "<span class='userdanger'>[user] lands a passable [tackle_word] on you, sending you both tumbling!</span>")
 
+			target.adjustBruteLoss(5 + bonus_damage)
 			target.adjustStaminaLoss(stamina_cost * 1.5)
 			target.Paralyze(5)
 			user.Knockdown(20)
@@ -188,7 +189,7 @@
 		if(1 to 2) // solid hit, tackler has a slight advantage
 			user.visible_message("<span class='warning'>[user] lands a solid [tackle_word] on [target], knocking them both down hard!</span>", "<span class='userdanger'>You land a solid [tackle_word] on [target], knocking you both down hard!</span>", target)
 			to_chat(target, "<span class='userdanger'>[user] lands a solid [tackle_word] on you, knocking you both down hard!</span>")
-
+			target.adjustBruteLoss(10 + bonus_damage)
 			target.adjustStaminaLoss(40)
 			target.Paralyze(5)
 			user.Knockdown(10)
@@ -201,6 +202,7 @@
 			user.SetKnockdown(0)
 			user.set_resting(FALSE, TRUE, FALSE)
 			user.forceMove(get_turf(target))
+			target.adjustBruteLoss(20 + bonus_damage)
 			target.adjustStaminaLoss(50)
 			target.Paralyze(3) //Otherwise the victim can just instantly get out of the grab.
 			target.DefaultCombatKnockdown(20) //So they cant get up instantly.
@@ -214,6 +216,7 @@
 			user.SetKnockdown(0)
 			user.set_resting(FALSE, TRUE, FALSE)
 			user.forceMove(get_turf(target))
+			target.adjustBruteLoss(30 + bonus_damage)
 			target.adjustStaminaLoss(65)
 			target.Paralyze(10)
 			target.DefaultCombatKnockdown(20)
@@ -297,7 +300,7 @@
 			attack_mod += 2
 			sacker.adjustStaminaLoss(20)
 
-	var/r = rand(-3, 3) - defense_mod + attack_mod + skill_mod + bonus_damage
+	var/r = rand(-3, 3) - defense_mod + attack_mod + skill_mod
 	return r
 
 

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -79,7 +79,7 @@
 
 /datum/quirk/freerunning
 	name = "Freerunning"
-	desc = "You're great at quick moves! You can climb tables more quickly."
+	desc = "You're great at quick moves! You can climb structures much faster and scale up walls!"
 	value = 2
 	mob_trait = TRAIT_FREERUNNING
 	gain_text = "<span class='notice'>You feel lithe on your feet!</span>"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -95,7 +95,6 @@
 	lose_text = "<span class='danger'>You start tromping around like a barbarian.</span>"
 	medical_record_text = "Patient's dexterity belies a strong capacity for stealth."
 
-/*
 /datum/quirk/quick_step
 	name = "Quick Step"
 	desc = "You walk with determined strides, and out-pace most people when walking."
@@ -104,7 +103,6 @@
 	gain_text = "<span class='notice'>You feel determined. No time to lose.</span>"
 	lose_text = "<span class='danger'>You feel less determined. What's the rush, man?</span>"
 	medical_record_text = "Patient scored highly on racewalking tests."
-*/
 
 /datum/quirk/photographer
 	name = "Photographer"
@@ -266,16 +264,7 @@
 	gain_text = "<span class='notice'>The mysteries of chemistry are revealed to you.</span>"
 	lose_text = "<span class='danger'>You forget how the periodic table works.</span>"
 	//locked = TRUE
-/*
-/datum/quirk/pa_wear
-	name = "PA Wear"
-	desc = "You've being around the wastes and have learned the importance of defense."
-	value = 3
-	mob_trait = TRAIT_PA_WEAR
-	gain_text = "<span class='notice'>You realize how to use Power Armor.</span>"
-	lose_text = "<span class='danger'>You forget how Power Armor works.</span>"
-	//locked = TRUE
-*/
+
 /datum/quirk/hard_yards
 	name = "Wasteland Maneuvers"
 	desc = "You know how to get around the wasteland, you ignore the slowdown effects of terrain."
@@ -402,7 +391,7 @@
 
 /datum/quirk/calcium_healer
 	name = "Calcium Healer"
-	desc = "Brahmin milk is a staple of a heavy society, drinking milk heals you."
+	desc = "Brahmin milk is a staple of a healthy society, drinking milk heals you."
 	value = 1
 	mob_trait = TRAIT_CALCIUM_HEALER
 	gain_text = "<span class='notice'>Got milk?'</span>"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -128,6 +128,12 @@
 	mob_trait = TRAIT_POOR_AIM
 	medical_record_text = "Patient possesses a strong tremor in both hands."
 
+/datum/quirk/fat_fingers
+	name = "Fat-Fingers"
+	desc = "Due to the shape of your hands, width of your fingers or just missing fingers entirely, you're unable to fire guns without accommodation."
+	value = -3
+	mob_trait = TRAIT_CHUNKYFINGERS
+
 /datum/quirk/prosopagnosia
 	name = "Prosopagnosia"
 	desc = "You have a mental disorder that prevents you from being able to recognize faces at all."
@@ -359,11 +365,20 @@
 // Some perks added to give some non-super crippling options for negatives.
 /datum/quirk/lifeloser
 	name = "Lifeloser"
-	desc = "You embody weakness! Instantly gain -10 maximum health!"
+	desc = "You embody weakness! Instantly lose 10 maximum health!"
 	value = -3
 	mob_trait = TRAIT_LIFELOSER
 	gain_text = "<span class='notice'>You feel less healthy than usual.</span>"
 	lose_text = "<span class='danger'>You feel more healthy than usual.</span>"
+
+
+/datum/quirk/lifeloser_big
+	name = "Big Lifeloser"
+	desc = "You embody weakness! Instantly lose 20 maximum health!"
+	value = -5
+	mob_trait = TRAIT_BIG_LIFELOSER
+	gain_text = "<span class='notice'>You feel alot less healthy than usual.</span>"
+	lose_text = "<span class='danger'>You feel alot more healthy than usual.</span>"
 
 // Was originally mirrored from lifegiver, which turns out hasn't worked for literal *years*. Defining it elsewhere. -Possum
 /*

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -468,14 +468,6 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	mob_tar.resize -= 0.1
 	mob_tar.update_transform()
 
-/obj/item/book/granter/trait/leaper_moderate
-	name = "DEBUG TEST: DELETE SOON"
-	desc = "How did you get this?"
-	oneuse = TRUE
-	granted_trait = TRAIT_LEAPER_MODERATE
-	traitname = "leaper_moderate"
-
-
 //SPECIAL integration
 /datum/quirk/leaper_weak
 	name = "SPECIAL: Leap"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -235,84 +235,6 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	H.equip_to_slot_if_possible(musicaltuner, SLOT_IN_BACKPACK)
 	H.regenerate_icons()
 
-/datum/quirk/fev //DOOM - Used in mob_tar creation && A secondary version for FEV-II exposure.
-	name = "Unstable FEV Exposure"
-	desc = "Be it accidental; the work of a mad scientist roaming the waste-land, or pre-war experiments that left an individual unable to die, this one has been exposed to an FEV Variation."
-	value = 0 // Locked
-	gain_text = span_notice("You feel a burning pain as your DNA is ripped apart, and sewn back together.")
-	lose_text = span_notice("The dull metronome of pain that defined your existence has faded.")
-	medical_record_text = "Patient appears to have 'perfect' DNA - if 'perfect' was a Wastelanders idea of beauty."
-	mob_trait = TRAIT_FEV
-	locked = TRUE
-
-/datum/quirk/fev/add()
-	var/mob/living/carbon/human/mob_tar = quirk_holder
-	mob_tar.dna.species.punchdamagelow += 6 //Larger Muscle-mass
-	mob_tar.dna.species.punchdamagehigh += 8 //But not too large. Reserved for FEV-II
-	quirk_holder.become_mega_nearsighted(ROUNDSTART_TRAIT) //Custom proc to make essentially welder-blindness.
-	mob_tar.maxHealth += 5 //These guys are tanky. Almost blind, and slower.
-	mob_tar.health += 5
-	mob_tar.resize += 0.05
-	mob_tar.update_transform()
-	to_chat(mob_tar, "<span class='notice'>You feel far stronger, and a tad dumber...</span>")
-
-/datum/quirk/fev/on_spawn()
-	var/mob/living/carbon/human/mob_tar = quirk_holder
-	mob_tar.dna.species.punchdamagelow += 6 //Larger Muscle-mass
-	mob_tar.dna.species.punchdamagehigh += 8 //But not too large. Reserved for FEV-II
-	quirk_holder.become_mega_nearsighted(ROUNDSTART_TRAIT) //Custom proc to make essentially welder-blindness.
-	mob_tar.maxHealth += 5 //These guys are tanky. Almost blind, and slower.
-	mob_tar.health += 5
-	to_chat(mob_tar, "<span class='notice'>You feel far stronger, and a tad dumber...</span>")
-
-/datum/quirk/fev/remove()
-	var/mob/living/carbon/human/mob_tar = quirk_holder
-	mob_tar.remove_mega_nearsighted()
-	mob_tar.maxHealth -= 5 //Mutie rage.
-	mob_tar.health -= 5
-	mob_tar.dna.species.punchdamagelow -= 6
-	mob_tar.dna.species.punchdamagehigh -= 8
-	mob_tar.resize -= 0.05
-	mob_tar.update_transform()
-
-/datum/quirk/fevII //FRANK FUCKING HORRIGAAAN
-	name = "FEV-II Exposure"
-	desc = "Direct exposure to FEV-II has caused unpredictable mutations to existing DNA."
-	value = 0 //Never unlockable naturally.
-	gain_text = span_notice("You feel a burning pain as your DNA is ripped apart, and sewn back together.")
-	lose_text = span_notice("The dull metronome of pain that defined your existence has faded.")
-	medical_record_text = "Patient has been exposed to FEV-II, with clear signs of triple-helix DNA present."
-	mob_trait = TRAIT_FEVII
-	locked = TRUE
-
-/datum/quirk/fevII/add()
-	var/mob/living/carbon/human/mob_tar = quirk_holder
-	mob_tar.dna.species.punchdamagelow += 8 //Fear.
-	mob_tar.dna.species.punchdamagehigh += 16  //Hurts!
-	mob_tar.maxHealth += 15 //Mutie rage.
-	mob_tar.health += 15
-	mob_tar.resize += 0.1
-	mob_tar.update_transform()
-	to_chat(mob_tar, "<span class='danger'>You feel extremely strong!</span>")
-
-/datum/quirk/fevII/on_spawn() //should never happen.
-	var/mob/living/carbon/human/mob_tar = quirk_holder
-	mob_tar.dna.species.punchdamagelow += 8 //Fear.
-	mob_tar.dna.species.punchdamagehigh += 16  //Hurts bad.
-	mob_tar.maxHealth += 15 //Mutie rage.
-	mob_tar.health += 15
-	to_chat(mob_tar, "<span class='danger'>You feel extremely strong!</span>")
-
-
-/datum/quirk/fevII/remove()
-	var/mob/living/carbon/human/mob_tar = quirk_holder
-	mob_tar.dna.species.punchdamagelow -= 8
-	mob_tar.dna.species.punchdamagehigh -= 16 //Prevents stacking
-	mob_tar.maxHealth -= 15 //Mutie rage.
-	mob_tar.health -= 15
-	mob_tar.resize -= 0.1
-	mob_tar.update_transform()
-
 /datum/quirk/pineapple_liker
 	name = "Ananas Affinity"
 	desc = "You find yourself greatly enjoying fruits of the ananas genus. You can't seem to ever get enough of their sweet goodness!"
@@ -463,3 +385,134 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	if(where == "in your backpack")
 		var/mob/living/carbon/human/H = quirk_holder
 		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
+
+
+// Purposefully locked perks, these reveal in-game what stat specials are required to obtain these perks.
+// Some perks that are always locked due to how they are assigned are also listed here aka FEV perks.
+/datum/quirk/fev //DOOM - Used in mob_tar creation && A secondary version for FEV-II exposure.
+	name = "SPECIAL: Unstable FEV Exposure"
+	desc = "Be it accidental; the work of a mad scientist roaming the waste-land, or pre-war experiments that left an individual unable to die, this one has been exposed to an FEV Variation. \
+	This trait must be gained through gameplay."
+	value = 0 // Locked
+	gain_text = span_notice("You feel a burning pain as your DNA is ripped apart, and sewn back together.")
+	lose_text = span_notice("The dull metronome of pain that defined your existence has faded.")
+	medical_record_text = "Patient appears to have 'perfect' DNA - if 'perfect' was a Wastelanders idea of beauty."
+	mob_trait = TRAIT_FEV
+	locked = TRUE
+
+/datum/quirk/fev/add()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.dna.species.punchdamagelow += 6 //Larger Muscle-mass
+	mob_tar.dna.species.punchdamagehigh += 8 //But not too large. Reserved for FEV-II
+	quirk_holder.become_mega_nearsighted(ROUNDSTART_TRAIT) //Custom proc to make essentially welder-blindness.
+	mob_tar.maxHealth += 5 //These guys are tanky. Almost blind, and slower.
+	mob_tar.health += 5
+	mob_tar.resize += 0.05
+	mob_tar.update_transform()
+	to_chat(mob_tar, "<span class='notice'>You feel far stronger, and a tad dumber...</span>")
+
+/datum/quirk/fev/on_spawn()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.dna.species.punchdamagelow += 6 //Larger Muscle-mass
+	mob_tar.dna.species.punchdamagehigh += 8 //But not too large. Reserved for FEV-II
+	quirk_holder.become_mega_nearsighted(ROUNDSTART_TRAIT) //Custom proc to make essentially welder-blindness.
+	mob_tar.maxHealth += 5 //These guys are tanky. Almost blind, and slower.
+	mob_tar.health += 5
+	to_chat(mob_tar, "<span class='notice'>You feel far stronger, and a tad dumber...</span>")
+
+/datum/quirk/fev/remove()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.remove_mega_nearsighted()
+	mob_tar.maxHealth -= 5 //Mutie rage.
+	mob_tar.health -= 5
+	mob_tar.dna.species.punchdamagelow -= 6
+	mob_tar.dna.species.punchdamagehigh -= 8
+	mob_tar.resize -= 0.05
+	mob_tar.update_transform()
+
+/datum/quirk/fevII //FRANK FUCKING HORRIGAAAN
+	name = "SPECIAL: FEV-II Exposure"
+	desc = "Direct exposure to FEV-II has caused unpredictable mutations to existing DNA. \
+	This trait must be gained through gameplay."
+	value = 0 //Never unlockable naturally.
+	gain_text = span_notice("You feel a burning pain as your DNA is ripped apart, and sewn back together.")
+	lose_text = span_notice("The dull metronome of pain that defined your existence has faded.")
+	medical_record_text = "Patient has been exposed to FEV-II, with clear signs of triple-helix DNA present."
+	mob_trait = TRAIT_FEVII
+	locked = TRUE
+
+/datum/quirk/fevII/add()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.dna.species.punchdamagelow += 8 //Fear.
+	mob_tar.dna.species.punchdamagehigh += 16  //Hurts!
+	mob_tar.maxHealth += 15 //Mutie rage.
+	mob_tar.health += 15
+	mob_tar.resize += 0.1
+	mob_tar.update_transform()
+	to_chat(mob_tar, "<span class='danger'>You feel extremely strong!</span>")
+
+/datum/quirk/fevII/on_spawn() //should never happen.
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.dna.species.punchdamagelow += 8 //Fear.
+	mob_tar.dna.species.punchdamagehigh += 16  //Hurts bad.
+	mob_tar.maxHealth += 15 //Mutie rage.
+	mob_tar.health += 15
+	to_chat(mob_tar, "<span class='danger'>You feel extremely strong!</span>")
+
+/datum/quirk/fevII/remove()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.dna.species.punchdamagelow -= 8
+	mob_tar.dna.species.punchdamagehigh -= 16 //Prevents stacking
+	mob_tar.maxHealth -= 15 //Mutie rage.
+	mob_tar.health -= 15
+	mob_tar.resize -= 0.1
+	mob_tar.update_transform()
+
+/obj/item/book/granter/trait/leaper_moderate
+	name = "DEBUG TEST: DELETE SOON"
+	desc = "How did you get this?"
+	oneuse = TRUE
+	granted_trait = TRAIT_LEAPER_MODERATE
+	traitname = "leaper_moderate"
+
+
+//SPECIAL integration
+/datum/quirk/leaper_weak
+	name = "SPECIAL: Leap"
+	desc = "You are agile enough to leap short distances, albiet somewhat clumsily. \
+	Having high agility (7) grants this trait automatically."
+	value = 0
+	mob_trait = TRAIT_LEAPER_WEAK
+	gain_text = "<span class='notice'>You feel like you can leap a good distance.</span>"
+	lose_text = "<span class='notice'>You lost your agility!</span>"
+	locked = TRUE
+
+/datum/quirk/leaper_moderate
+	name = "SPECIAL: Lunge"
+	desc = "You are incredibly agile and can leap incredible distances as a result, provided you are not weighed down by muscle mass. \
+	Being extraordinarily agile (9) will grant this trait automatically, having extraordinary strength (9) will grant tackle instead."
+	value = 0
+	mob_trait = TRAIT_LEAPER_MODERATE
+	gain_text = "<span class='notice'>You feel like you can leap amazingly far!</span>"
+	lose_text = "<span class='notice'>You've lost your agility!</span>"
+	locked = TRUE
+
+/datum/quirk/leaper_strong
+	name = "SPECIAL: Tackle"
+	desc = "You can leap medium distances and, if colliding with someone, will likely knock them down due to your strength and bulk. \
+	Having extraordinary agility (9) and extraordinary strength (9) will grant this trait automatically."
+	value = 0
+	mob_trait = TRAIT_LEAPER_STRONG
+	gain_text = "<span class='notice'>You're a battering ram!</span>"
+	lose_text = "<span class='notice'>You feel slow and weak.</span>"
+	locked = TRUE
+
+/datum/quirk/pa_wear
+	name = "SPECIAL: Power Armor Training"
+	desc = "Either through training or skill you have become capable of donning and using power armor. \
+	Having extraordinary intellect (9), high strength (7), and high endurance (7) will grant this trait automatically."
+	value = 0
+	mob_trait = TRAIT_PA_WEAR
+	gain_text = "<span class='notice'>You realize how to use Power Armor.</span>"
+	lose_text = "<span class='danger'>You forget how Power Armor works.</span>"
+	locked = TRUE

--- a/code/modules/antagonists/bloodsucker/powers/lunge.dm
+++ b/code/modules/antagonists/bloodsucker/powers/lunge.dm
@@ -1,5 +1,3 @@
-
-
 /datum/action/bloodsucker/lunge
 	name = "Predatory Lunge"
 	desc = "Prepare the strenght to grapple your prey."
@@ -13,7 +11,7 @@
 
 /datum/action/bloodsucker/lunge/New()
 	. = ..()
-	
+
 
 /datum/action/bloodsucker/lunge/Destroy()
 	. = ..()
@@ -37,7 +35,7 @@
 		sleep(5)
 
 //Without this, the leap component would get removed too early, causing the normal crash into effects.
-/datum/action/bloodsucker/lunge/proc/DelayedDeactivatePower() 
+/datum/action/bloodsucker/lunge/proc/DelayedDeactivatePower()
 	addtimer(CALLBACK(src, .proc/DeactivatePower), 1 SECONDS, TIMER_UNIQUE)
 
 /datum/action/bloodsucker/lunge/DeactivatePower(mob/living/user = owner)

--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -355,6 +355,121 @@
 	..()
 	icon_state = "rock[rand(1,6)]"
 
+// Free Running perk!
+/turf/closed/wall/AltClick(mob/user)
+	. = ..()
+	if(can_climb(user))
+		return climb_wall(user)
+
+/turf/closed/wall/proc/can_climb(mob/living/user)
+	if(!istype(user))
+		return
+	if(INTERACTING_WITH(user, src))
+		return
+	if(user.stat)
+		return
+	if(!user.can_reach(src))
+		return
+	if(user.restrained())
+		return
+	if(!is_climbable(user))
+		to_chat(user, span_alert("You briefly consider climbing the wall, but it is just too perilous to climb! You'd probably fall and break your neck!"))
+		return
+	if(!HAS_TRAIT(user, TRAIT_FREERUNNING))
+		return
+	if(HAS_TRAIT(user, TRAIT_SHACKLEDRUNNING))
+		return
+	return TRUE
+
+/turf/closed/wall/proc/climb_wall(mob/living/user)
+	if(!istype(user))
+		return
+	if(!can_climb(user))
+		return
+	if(HAS_TRAIT(user, TRAIT_FAT))
+		to_chat(user, span_warning("You try to climb up [src], but your big fat gut gets in the way!"))
+		return
+	var/turf/AboveT = get_step_multiz(get_turf(user), UP)
+	var/turf/targetDest = get_step_multiz(get_turf(src), UP)
+	if(!can_climb_to(user, targetDest, AboveT))
+		return
+	var/time_to_climb = 10 SECONDS
+	if(user.getStaminaLoss() > 0)
+		time_to_climb += user.getStaminaLoss() * 0.25 // 25% of your stamina loss will effect the speed on climbing.
+	if(HAS_TRAIT(user, TRAIT_FREERUNNING) && !HAS_TRAIT(user, TRAIT_SHACKLEDRUNNING))
+		time_to_climb *= 0.25 // Free runners climb 75% faster.
+	visible_message(
+		span_warning("[user] starts climbing up [name]!"),
+		span_notice("You start climbing up [name]!")
+	)
+	//SSweather.add_sound_rock(user, /datum/looping_sound/rockpile)
+	var/failed = FALSE
+	if(!do_after(user, time_to_climb, TRUE, src, TRUE))
+		failed = TRUE
+	if(!can_climb_to(user, targetDest, AboveT))
+		failed = TRUE
+		return
+	//SSweather.remove_sound_rock(user, /datum/looping_sound/rockpile)
+	if(failed)
+		if(HAS_TRAIT(user, TRAIT_FREERUNNING))
+			visible_message(
+				span_alert("[user] slips and falls! Shoot!"),
+				span_alert("You slip and fall! But, you land on your feet (or whatever it is you use)!"))
+		else
+			visible_message(
+				span_alert("[user] slips and falls flat on their behind! Shoot!"),
+				span_alert("You slip and fall! Shoot!"))
+			user.DefaultCombatKnockdown(1) // just a lil one
+		return
+	if(user.zMove(UP, targetDest, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK))
+		visible_message(
+			span_notice("[user] climbs up [src]!"),
+			span_notice("You climb up [src]!"))
+		if(!HAS_TRAIT(user, TRAIT_FREERUNNING))
+			user.DefaultCombatKnockdown(1, override_stamdmg = 5) // just a lil one
+
+/turf/closed/wall/proc/is_climbable(mob/user)
+	return TRUE // This is just a placeholder for now. We'll add more stuff later.
+
+/turf/closed/wall/proc/can_climb_to(mob/living/user, turf/targetDest, turf/AboveT)
+	var/thingelephant = "something"
+	var/ceilingeleephant = "ceiling"
+	if(prob(0.1))
+		ceilingeleephant = "elephant"
+		thingelephant = "an elephant"
+	if(!istype(AboveT, /turf/open/transparent/openspace))
+		to_chat(user, "You can't get here, there is \a [ceilingeleephant] in the way!") // (0)
+		return
+	if(istype(targetDest, /turf/open/transparent/openspace))
+		to_chat(user, span_warning("There's nothing to stand on up there!"))
+		return
+	if(istype(targetDest, /turf/closed) || istype(AboveT, /turf/closed))
+		to_chat(user, span_warning("On top of the wall seems to be more wall! You can't get up there")) // (1)
+		return
+	var/list/stuff_to_check = list()
+	stuff_to_check |= targetDest.contents
+	stuff_to_check |= AboveT.contents
+	stuff_to_check |= targetDest
+	stuff_to_check |= AboveT
+	var/bad
+	for(var/atom/A in stuff_to_check)
+		if(A.density)
+			bad = TRUE
+			break
+		// if(!A.CanPass(user, get_dir(AboveT, targetDest)))
+		// 	bad = TRUE
+		// 	break
+		// if(!A.CanPass(user, get_dir(AboveT, targetDest)))
+		// 	bad = TRUE
+		// 	break
+		// if(istype(A, /obj/structure) && A.density) // stop climbing into railings and stuff
+		// 	bad = TRUE
+		// 	break
+	if(bad)
+		to_chat(user, span_warning("There's [thingelephant] in the way! You can't go there!"))
+		return
+	return TRUE // If we got here, we can climb!
+
 //Splashscreen
 /*
 /turf/closed/indestructible/f13/splashscreen

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -307,15 +307,17 @@
 
 	if(chemwhiz == TRUE)
 		ADD_TRAIT(H, TRAIT_CHEMWHIZ, "chemwhiz")
-		var/list/chem_types = list(/datum/crafting_recipe/jet, /datum/crafting_recipe/turbo, /datum/crafting_recipe/psycho, /datum/crafting_recipe/medx, /datum/crafting_recipe/buffout)
-		for(var/datum/crafting_recipe/R in chem_types)
-			H.mind.teach_crafting_recipe(R)
+		//var/list/chem_types = list(/datum/crafting_recipe/jet, /datum/crafting_recipe/turbo, /datum/crafting_recipe/psycho, /datum/crafting_recipe/medx, /datum/crafting_recipe/buffout)
+		//for(var/datum/crafting_recipe/R in chem_types)
+		//	H.mind.teach_crafting_recipe(R)
 
 	if(pa_wear == TRUE)
 		ADD_TRAIT(H, TRAIT_PA_WEAR, "pa_wear")
 
 	if(vb_pilot == TRUE)
 		ADD_TRAIT(H, TRAIT_PILOT, "vb_pilot")
+// This is commented out because it doesn't actually work, perks that call for a proc always fail during init.
+// Leaving this note so nobody else makes the same mistake. Also applies to Chem Wiz above. -Possum
 /*
 	var/list/gun_types
 	if(gunsmith_one == TRUE)
@@ -391,47 +393,7 @@
 			T.linked_mob = H
 	//Fortuna edit end. radio management
 
-	//SPECIAL integration
-	if(H.special_i >= 3)
-		ADD_TRAIT(H, TRAIT_TRIBAL, "tribal")
-	if(H.special_i >= 5)
-		ADD_TRAIT(H, TRAIT_GUNSMITH_ONE, "gunsmith_one")
-	if(H.special_i >= 7)
-		ADD_TRAIT(H, TRAIT_GUNSMITH_TWO, "gunsmith_two")
-		ADD_TRAIT(H, TRAIT_EXPLOSIVE_CRAFTING, "explosive_crafting")
-	if(H.special_i >= 9)
-		if(vb_pilot == FALSE)
-			ADD_TRAIT(H, TRAIT_PILOT, "vb_pilot")
-		ADD_TRAIT(H, TRAIT_GUNSMITH_THREE, "gunsmith_three")
-		ADD_TRAIT(H, TRAIT_GUNSMITH_FOUR, "gunsmith_four")
 
-	if(H.special_i >= 9 && H.special_e >= 7 && H.special_s >= 7) // Represents a smart and strong person brute forcing PA training.
-		if(pa_wear == FALSE)
-			ADD_TRAIT(H, TRAIT_PA_WEAR, "pa_wear")
-
-	if(H.special_c >= 7)
-		H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
-	if(H.special_c >= 9)
-		H.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
-/*
-	if(H.special_a >= 7 && H.special_a < 9)
-		var/datum/component/tackler/T = H.AddComponent(/datum/component/tackler)
-		T.stamina_cost = 25
-		T.base_knockdown = 0
-		T.range = 4
-		T.speed = 1
-		T.skill_mod = 0
-		T.min_distance = 1
-
-	if(H.special_a >= 9)
-		var/datum/component/tackler/T = H.AddComponent(/datum/component/tackler)
-		T.stamina_cost = 15
-		T.base_knockdown = 0
-		T.range = 7
-		T.speed = 1
-		T.skill_mod = 0
-		T.min_distance = 1
-*/
 /datum/outfit/job/get_chameleon_disguise_info()
 	var/list/types = ..()
 	types -= /obj/item/storage/backpack //otherwise this will override the actual backpacks

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -413,7 +413,25 @@
 		H.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
 	if(H.special_c >= 9)
 		H.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
+/*
+	if(H.special_a >= 7 && H.special_a < 9)
+		var/datum/component/tackler/T = H.AddComponent(/datum/component/tackler)
+		T.stamina_cost = 25
+		T.base_knockdown = 0
+		T.range = 4
+		T.speed = 1
+		T.skill_mod = 0
+		T.min_distance = 1
 
+	if(H.special_a >= 9)
+		var/datum/component/tackler/T = H.AddComponent(/datum/component/tackler)
+		T.stamina_cost = 15
+		T.base_knockdown = 0
+		T.range = 7
+		T.speed = 1
+		T.skill_mod = 0
+		T.min_distance = 1
+*/
 /datum/outfit/job/get_chameleon_disguise_info()
 	var/list/types = ..()
 	types -= /obj/item/storage/backpack //otherwise this will override the actual backpacks

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -64,6 +64,7 @@
 			T.speed = 1
 			T.skill_mod = 0
 			T.min_distance = 1
+			ADD_TRAIT(src, TRAIT_LEAPER_WEAK, "leaper_weak")
 		// Super agile and not THICC
 		if(src.special_a >= 9 && src.special_s < 9)
 			src.AddComponent(/datum/component/tackler/weak)
@@ -74,6 +75,7 @@
 			T.speed = 2
 			T.skill_mod = 0
 			T.min_distance = 1
+			ADD_TRAIT(src, TRAIT_LEAPER_MODERATE, "leaper_moderate")
 		// If you have 9 strength you are THICC, can't leap as far but you hit harder and stun on impact.
 		if(src.special_a >= 9 && src.special_s >= 9)
 			src.AddComponent(/datum/component/tackler/strong)
@@ -84,6 +86,7 @@
 			T.speed = 1
 			T.skill_mod = 3
 			T.min_distance = 1
+			ADD_TRAIT(src, TRAIT_LEAPER_STRONG, "leaper_strong")
 
 		// COMBO STATS
 		// Int/End/Str - Represents a smart and strong person brute forcing PA training.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -17,6 +17,9 @@
 		if(HAS_TRAIT(src, TRAIT_LIFELOSER))
 			src.maxHealth -= 10
 			src.health -= 10
+		if(HAS_TRAIT(src, TRAIT_BIG_LIFELOSER))
+			src.maxHealth -= 20
+			src.health -= 20
 
 
 		//SPECIAL integration MAIN
@@ -76,7 +79,7 @@
 			src.AddComponent(/datum/component/tackler/strong)
 			var/datum/component/tackler/strong/T = src.LoadComponent(/datum/component/tackler/strong)
 			T.stamina_cost = 20
-			T.base_knockdown = 1
+			T.base_knockdown = 0
 			T.range = 5
 			T.speed = 1
 			T.skill_mod = 3

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -17,9 +17,77 @@
 		if(HAS_TRAIT(src, TRAIT_LIFELOSER))
 			src.maxHealth -= 10
 			src.health -= 10
-		src.maxHealth += (src.special_e*3)//SPECIAL Integration
-		src.health += (src.special_e*3)//SPECIAL Integration
-		update_special_speed((5-src.special_a)/20)//SPECIAL Integration
+
+
+		//SPECIAL integration MAIN
+		// This is the primary spot for all stat based special bonuses that are passive.
+		// Primarily because its easy to debug this in round. -Possum
+
+		// ENDURANCE
+		src.maxHealth += (src.special_e*3)
+		src.health += (src.special_e*3)
+
+		// INTELLIGENCE
+		if(src.special_i >= 3)
+			ADD_TRAIT(src, TRAIT_TRIBAL, "tribal")
+		if(src.special_i >= 5)
+			ADD_TRAIT(src, TRAIT_GUNSMITH_ONE, "gunsmith_one")
+		if(src.special_i >= 7)
+			ADD_TRAIT(src, TRAIT_GUNSMITH_TWO, "gunsmith_two")
+			ADD_TRAIT(src, TRAIT_EXPLOSIVE_CRAFTING, "explosive_crafting")
+		if(src.special_i >= 9)
+			ADD_TRAIT(src, TRAIT_PILOT, "vb_pilot")
+			ADD_TRAIT(src, TRAIT_GUNSMITH_THREE, "gunsmith_three")
+			ADD_TRAIT(src, TRAIT_GUNSMITH_FOUR, "gunsmith_four")
+
+		// CHARISMA
+		// Both of these spells are in terrifying_presence.dm
+		if(src.special_c >= 7)
+			src.AddSpell(new /obj/effect/proc_holder/spell/terrifying_presence)
+		if(src.special_c >= 9)
+			src.AddSpell(new /obj/effect/proc_holder/spell/ferocious_loyalty)
+
+		// AGILITY
+		// The below line affects movement speed.
+		update_special_speed((5-src.special_a)/20)
+
+		// Basic leap
+		if(src.special_a >= 7 && src.special_a < 9)
+			src.AddComponent(/datum/component/tackler/weak)
+			var/datum/component/tackler/weak/T = src.LoadComponent(/datum/component/tackler/weak)
+			T.stamina_cost = 30
+			T.base_knockdown = 0
+			T.range = 4
+			T.speed = 1
+			T.skill_mod = 0
+			T.min_distance = 1
+		// Super agile and not THICC
+		if(src.special_a >= 9 && src.special_s < 9)
+			src.AddComponent(/datum/component/tackler/weak)
+			var/datum/component/tackler/weak/T = src.LoadComponent(/datum/component/tackler/weak)
+			T.stamina_cost = 20
+			T.base_knockdown = 0
+			T.range = 7
+			T.speed = 2
+			T.skill_mod = 0
+			T.min_distance = 1
+		// If you have 9 strength you are THICC, can't leap as far but you hit harder and stun on impact.
+		if(src.special_a >= 9 && src.special_s >= 9)
+			src.AddComponent(/datum/component/tackler/strong)
+			var/datum/component/tackler/strong/T = src.LoadComponent(/datum/component/tackler/strong)
+			T.stamina_cost = 20
+			T.base_knockdown = 1
+			T.range = 5
+			T.speed = 1
+			T.skill_mod = 3
+			T.min_distance = 1
+
+		// COMBO STATS
+		// Int/End/Str - Represents a smart and strong person brute forcing PA training.
+		if(src.special_i >= 9 && src.special_e >= 7 && src.special_s >= 7)
+			ADD_TRAIT(src, TRAIT_PA_WEAR, "pa_wear")
+
+
 		SPECIAL_SET = TRUE
 
 	//SHOULD_NOT_SLEEP(TRUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -56,10 +56,15 @@
 	return ..()
 
 /mob/living/proc/ZImpactDamage(turf/T, levels)
-	visible_message("<span class='danger'>[src] crashes into [T] with a sickening noise!</span>", \
-					"<span class='userdanger'>You crash into [T] with a sickening noise!</span>")
-	adjustBruteLoss((levels * 5) ** 1.5)
-	DefaultCombatKnockdown(levels * 50)
+	if(levels <= 2 && HAS_TRAIT(src, TRAIT_FREERUNNING) && !HAS_TRAIT(src, TRAIT_SHACKLEDRUNNING)) //levels is incremented prior to damage proc and is always >= 2
+		visible_message(span_danger("[src] slams into [T], rolling as they land and keeping their pace!"),
+						span_userdanger("You slam into [T], rolling and keeping your momentum!"))
+		adjustBruteLoss(5)
+	else
+		visible_message(span_danger("[src] crashes into [T] with a sickening noise!"),
+						span_userdanger("You crash into [T] with a sickening noise!"))
+		adjustBruteLoss((levels * 5) ** 1.5)
+		DefaultCombatKnockdown(levels * 50)
 
 
 /mob/living/proc/OpenCraftingMenu()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -525,7 +525,7 @@ ATTACHMENTS
 
 	if(on_cooldown())
 		return
-	if(user.IsWeaponDrawDelayed() && user.special_p >= 7)//SPECIAL Integration
+	if(user.IsWeaponDrawDelayed() && user.special_p < 7)//SPECIAL Integration
 		to_chat(user, "<span class='notice'>[src] is not yet ready to fire!</span>")
 		return
 	firing = TRUE
@@ -1012,7 +1012,7 @@ ATTACHMENTS
 /obj/item/gun/proc/getinaccuracy(mob/living/user, bonus_spread, stamloss)
 	if(inaccuracy_modifier == 0)
 		return bonus_spread
-	var/base_inaccuracy = weapon_weight * 25 * inaccuracy_modifier + 45 + (-user.special_p*5)//SPECIAL Integration
+	var/base_inaccuracy = weapon_weight * 25 * inaccuracy_modifier + 180 + (-user.special_p*20)//SPECIAL Integration
 	var/aiming_delay = 0 //Otherwise aiming would be meaningless for slower guns such as sniper rifles and launchers.
 	if(fire_delay)
 		var/penalty = (last_fire + GUN_AIMING_TIME + fire_delay) - world.time


### PR DESCRIPTION
-The penalty to recoil is now 180, up from 45, the recoil control gained from stats is now *20, up from *5.
-Added 3 traits for leaping.
-Completely ported and adjusted the tackle system from CB but with some changes, mainly special integration for damage and effects.
-Fixed a typo in calcium healer.
-Neutral perks now holds locked traits under the SPECIAL tag that show traits gained via stat combos. Helpful for new players who might not otherwise know the difference.
-Commented out a section for chemwiz in _job.dm since it didn't work.
-Moved special integration from _job.dm post_equip() to life.dm since that is both cleaner and easier to manage. Cleaned up the code a little too.
-Added the negative perk "Big Lifeloser" that gives you 5 points at the cost of -20 maximum health.
-Added chunky fingers to negative perks as a -3 cost (prevents most gun use).
-Free running now allows you to climb walls if there is nothing preventing you from going upwards. I.E. there is open space directly above the wall, you, and no dense objects would otherwise block movement.
-Free running reduces fall damage to 5 from dropping down 1-2 floors and prevents you from being knocked down on landing.
-Corrected a weird grammar on lifeloser.

Didn't runtime and everything seemed to work fine. Yay for mobility.