### PR TITLE
Raider Armor V2, More Special Integration, Fixes

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -202,7 +202,7 @@
 	gain_text = "<span class='notice'>You are now able to use primitive technology.</span>"
 	lose_text = "<span class='danger'>You are no longer able to use primitive technology.</span>"
 	//locked = TRUE
-
+/*
 /datum/quirk/night_vision
 	name = "Night Vision"
 	desc = "You can see slightly more clearly in full darkness than most people."
@@ -215,7 +215,7 @@
 /datum/quirk/night_vision/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.update_sight()
-
+*/
 /datum/quirk/nukalover
 	name = "Nuka Fiend"
 	desc = "You are a fan of America's most popular pre-war soft drink. Your body simply loves the sugary drink so much, it rejects healthier alternatives."

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -255,7 +255,7 @@
 /obj/item/restraints/legcuffs/beartrap/Initialize(mapload)
 	. = ..()
 	icon_state = "[initial(icon_state)][armed]"
-	
+
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
@@ -295,6 +295,8 @@
 				if(SA.mob_size > MOB_SIZE_TINY)
 					snap = TRUE
 			if(L.movement_type & (FLYING | FLOATING))
+				snap = FALSE
+			if(L.special_p >= 7)
 				snap = FALSE
 			if(snap)
 				armed = FALSE
@@ -355,7 +357,7 @@
  * * C - the carbon that we will try to ensnare
  */
 /obj/item/restraints/legcuffs/bola/proc/ensnare(mob/living/carbon/C)
-	if(!C.legcuffed && C.get_num_legs(FALSE) >= 2)
+	if(!C.legcuffed && C.get_num_legs(FALSE) >= 2 && C.special_p >= 9)
 		visible_message("<span class='danger'>\The [src] ensnares [C]!</span>")
 		C.legcuffed = src
 		forceMove(C)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -471,7 +471,7 @@ BLIND     // can't see anything
 				to_chat(M, "<span class='warning'>Your species cannot wear [src].</span>")
 				return FALSE
 
-	if(HAS_TRAIT(M, TRAIT_RAIDER_ARMOR) && !raider_armor && slot_flags == ITEM_SLOT_OCLOTHING)
+	if(HAS_TRAIT(M, TRAIT_RAIDER_ARMOR) && !raider_armor)// && slot_flags == ITEM_SLOT_OCLOTHING)
 		to_chat(M, "<span class='warning'>You can't wear this! You're a badass raider and need to look the part!</span>")
 		return 0
 

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -14,6 +14,7 @@
 	var/invis_override = 0 //Override to allow glasses to set higher than normal see_invis
 	var/list/icon/current = list() //the current hud icons
 	var/vision_correction = 0 //does wearing these glasses correct some of our vision defects?
+	raider_armor = TRUE
 
 /obj/item/clothing/glasses/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is stabbing \the [src] into [user.p_their()] eyes! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/clothing/gloves/f13gloves.dm
+++ b/code/modules/clothing/gloves/f13gloves.dm
@@ -25,6 +25,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	raider_armor = TRUE
 
 /obj/item/clothing/gloves/f13/leather/fingerless
 	name = "fingerless leather gloves"
@@ -74,6 +75,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	raider_armor = TRUE
 
 /obj/item/clothing/gloves/f13/lace
 	name = "lace gloves"
@@ -100,6 +102,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	raider_armor = TRUE
 
 /obj/item/clothing/gloves/f13/crudemedical
 	name = "crude medical gloves"
@@ -108,6 +111,7 @@
 	item_state = "offwhite"
 	siemens_coefficient = 0.5
 	permeability_coefficient = 0.1
+	raider_armor = TRUE
 
 /obj/item/clothing/gloves/f13/mutant
 	name = "mutant bracers"

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -57,6 +57,7 @@
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	dynamic_hair_suffix = ""
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 5, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 0, "wound" = 15)
+	raider_armor = TRUE
 
 /obj/item/clothing/head/helmet/f13/raider/supafly
 	name = "supa-fly raider helmet"
@@ -116,6 +117,7 @@
 	flags_inv = HIDEEARS
 	dynamic_hair_suffix = "+generic"
 	armor = list("melee" = 45, "bullet" = 30, "laser" = 30, "energy" = 5, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 0, "wound" = 15)
+	raider_armor = TRUE
 
 /obj/item/clothing/head/helmet/f13/fiend_reinforced
 	name = "reinforced fiend helmet"
@@ -123,15 +125,17 @@
 	icon_state = "fiend"
 	item_state = "fiend"
 	armor = list("melee" = 50, "bullet" = 35, "laser" = 35, "energy" = 5, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 0, "wound" = 20)
+	raider_armor = TRUE
 
 /obj/item/clothing/head/helmet/f13/jackal
 	name = "jackal headwrap"
-	desc = "A cloth head wrap that secures around the user's head, sporting a few rienforced points of leather underneath."
+	desc = "A cloth head wrap that secures around the user's head, sporting a few reinforced points of leather underneath."
 	icon = 'icons/fallout/clothing/hats.dmi'
 	icon_state = "jackal"
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
 	armor = list("melee" = 35, "bullet" = 20, "laser" = 10, "energy" = 0, "bomb" = 25, "bio" = 20, "rad" = 30, "fire" = 30, "acid" = 20, "wound" = 10)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
+	raider_armor = TRUE
 
 /obj/item/clothing/head/helmet/f13/jackal/Initialize(mapload)
 	. = ..()
@@ -143,6 +147,7 @@
 	icon_state = "raidermetal"
 	item_state = "raidermetal"
 	armor = list("melee" = 20, "bullet" = 35, "laser" = 20, "energy" = 5, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 0, "wound" = 15)
+	raider_armor = TRUE
 
 /obj/item/clothing/head/helmet/f13/raidercombathelmet
 	name = "combat raider helmet"
@@ -150,6 +155,7 @@
 	icon_state = "raider_combat_helmet"
 	item_state = "raider_combat_helmet"
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 10, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 15, "acid" = 0, "wound" = 15)
+	raider_armor = TRUE
 
 ///////////
 //ENCLAVE//

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -91,6 +91,7 @@
 	icon_state = "combat_helmet_raider"
 	item_state = "combat_helmet_raider"
 	armor = list("melee" = 45, "bullet" = 35, "laser" = 35, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 10, "fire" = 15, "acid" = 0, "wound" = 15)
+	raider_armor = TRUE
 
 /obj/item/clothing/head/helmet/f13/combat/rangerbroken
 	name = "broken riot helmet"
@@ -141,6 +142,7 @@
 	dynamic_hair_suffix = ""
 	armor = list("melee" = 40, "bullet" = 45, "laser" = 55, "energy" = 15, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 0, "wound" = 25)
 	slowdown = 0.02
+	raider_armor = TRUE
 
 //Metal
 
@@ -581,6 +583,7 @@
 	icon_state = "stormchaser"
 	item_state = "fedora"
 	flags_inv = HIDEEARS|HIDEHAIR
+	raider_armor = TRUE
 
 /obj/item/clothing/head/f13/headscarf
 	name = "headscarf"

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -94,6 +94,7 @@
 	desc = "A heavily modified, almost bastardised T-45d power armor helmet."
 	icon_state = "raiderpa_helm"
 	item_state = "raiderpa_helm"
+	raider_armor = TRUE
 
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d/hotrod
 	name = "hotrod salvaged power helmet"

--- a/code/modules/clothing/shoes/f13.dm
+++ b/code/modules/clothing/shoes/f13.dm
@@ -35,6 +35,7 @@
 	icon_state = "brownie"
 	item_state = "brownie"
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/shoes/f13/fancy
 	name = "black shoes"
@@ -60,6 +61,7 @@
 	icon_state = "raidertreads"
 	item_state = "raidertreads"
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/shoes/f13/diesel
 	name = "male diesel boots"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -107,6 +107,7 @@
 	permeability_coefficient = 0.05 //Thick soles, and covers the ankle
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
 	lace_time = 12 SECONDS
+	raider_armor = TRUE
 
 /obj/item/clothing/shoes/jackboots/fast
 	slowdown = -1

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -506,6 +506,7 @@
 	armor = list("melee" = 55, "bullet" = 40, "laser" = 40, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 0, "wound" = 35)
 	slowdown = 0.06
 	mutantrace_variation = STYLE_DIGITIGRADE
+	damage_threshold = DT_ADVANCED // Special since legendary deathclaw
 
 /obj/item/clothing/head/hooded/cloakhood/hhunter
 	name = "Razorclaw helm"

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -9,6 +9,7 @@
 	var/above_suit = FALSE
 	var/minimize_when_attached = TRUE // TRUE if shown as a small icon in corner, FALSE if overlayed
 	var/datum/component/storage/detached_pockets
+	raider_armor = TRUE
 
 /obj/item/clothing/accessory/proc/attach(obj/item/clothing/under/U, user)
 	var/datum/component/storage/storage = GetComponent(/datum/component/storage)

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -171,6 +171,7 @@
 	item_state = "ncrcf"
 	item_color = "ncrcf"
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 //Settlers
 
@@ -696,6 +697,7 @@
 	icon_state = "raider_leather"
 	item_state = "raider_leather"
 	item_color = "raider_leather"
+	raider_armor = TRUE
 
 /obj/item/clothing/under/f13/raiderrags
 	name = "raider rags"
@@ -704,6 +706,7 @@
 	item_state = "raiderrags"
 	item_color = "raiderrags"
 	mutantrace_variation = STYLE_DIGITIGRADE
+	raider_armor = TRUE
 
 /obj/item/clothing/under/f13/khan
 	name = "great khan uniform"
@@ -1758,6 +1761,7 @@
 	icon_state = "raiderharness"
 	item_state = "raiderharness"
 	item_color = "raiderharness"
+	raider_armor = TRUE
 
 /obj/item/clothing/under/f13/fprostitute
 	name = "feminine prostitute outfit"

--- a/code/modules/fallout/reagents/drinks.dm
+++ b/code/modules/fallout/reagents/drinks.dm
@@ -230,9 +230,6 @@
 	water_level = 1.75
 
 /datum/reagent/consumable/nukaice/on_mob_life(mob/living/carbon/M)
-	if(HAS_TRAIT(M, TRAIT_NUKA_LOVER))
-		M.adjustBruteLoss(-0.05, updating_health = FALSE)
-		M.adjustFireLoss(-0.05, updating_health = FALSE)
 	M.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT, T0C) //310.15 is the normal bodytemp.
 	M.drowsyness = 0
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)

--- a/code/modules/jobs/job_types/raider.dm
+++ b/code/modules/jobs/job_types/raider.dm
@@ -113,11 +113,9 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	)
 
 /datum/outfit/loadout/raider_powder
-	name = "Raider Ganger"
-	suit = /obj/item/clothing/suit/armor/f13/raider/ncrcfarmor
-	head = /obj/item/clothing/head/f13/stormchaser
-	uniform = /obj/item/clothing/under/f13/ncrcf
-	shoes = /obj/item/clothing/shoes/f13/brownie
+	name = "Raider Bomber"
+	suit = /obj/item/clothing/suit/armor/f13/raider/blastmaster
+	head = /obj/item/clothing/head/helmet/f13/raider/blastmaster
 	backpack_contents = list(
 		/obj/item/grenade/homemade/dynamite = 4,
 		/obj/item/gun/ballistic/revolver/caravan_shotgun = 1,
@@ -131,7 +129,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 /datum/outfit/loadout/raider_smith
 	name = "Raider Smith"
 	suit = /obj/item/clothing/suit/armored/heavy/raidermetal
-	uniform = /obj/item/clothing/under/f13/raider_leather
+	uniform = /obj/item/clothing/under/f13/raiderharness
 	head = /obj/item/clothing/head/helmet/f13/raider/arclight
 	gloves = /obj/item/clothing/gloves/f13/blacksmith
 	backpack_contents = list(
@@ -148,7 +146,8 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 /datum/outfit/loadout/raider_sawbones
 	name = "Raider Sawbones"
 	suit = /obj/item/clothing/suit/armor/f13/raider/sadist
-	shoes = /obj/item/clothing/shoes/jackboots
+	uniform = /obj/item/clothing/under/f13/raiderrags
+	gloves = /obj/item/clothing/gloves/f13/crudemedical
 	l_hand = /obj/item/storage/backpack/duffelbag/med/surgery
 	r_hand = /obj/item/book/granter/trait/midsurgery
 	suit_store = /obj/item/gun/energy/laser/wattz

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -526,14 +526,14 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 	//SPECIAL integration
 	if(special_e >= 7)
-		adjustBruteLoss(-0.01, updating_health = FALSE)
-		adjustFireLoss(-0.01, updating_health = FALSE)
-		adjustToxLoss(-0.01, updating_health = FALSE)
+		adjustBruteLoss(-0.02, updating_health = FALSE)
+		adjustFireLoss(-0.02, updating_health = FALSE)
+		adjustToxLoss(-0.02, updating_health = FALSE)
 
 	if(special_e >= 9)
-		adjustBruteLoss(-0.01, updating_health = FALSE)
-		adjustFireLoss(-0.01, updating_health = FALSE)
-		adjustToxLoss(-0.01, updating_health = FALSE)
+		adjustBruteLoss(-0.02, updating_health = FALSE)
+		adjustFireLoss(-0.02, updating_health = FALSE)
+		adjustToxLoss(-0.02, updating_health = FALSE)
 	// Stacks together.
 
 	var/restingpwr = 1 + 4 * !CHECK_MOBILITY(src, MOBILITY_STAND)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -524,6 +524,18 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		bufferedstam = max(bufferedstam - drainrate, 0)
 	//END OF CIT CHANGES
 
+	//SPECIAL integration
+	if(special_e >= 7)
+		adjustBruteLoss(-0.01, updating_health = FALSE)
+		adjustFireLoss(-0.01, updating_health = FALSE)
+		adjustToxLoss(-0.01, updating_health = FALSE)
+
+	if(special_e >= 9)
+		adjustBruteLoss(-0.01, updating_health = FALSE)
+		adjustFireLoss(-0.01, updating_health = FALSE)
+		adjustToxLoss(-0.01, updating_health = FALSE)
+	// Stacks together.
+
 	var/restingpwr = 1 + 4 * !CHECK_MOBILITY(src, MOBILITY_STAND)
 
 	//Dizziness

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -29,7 +29,6 @@
 		// STRENGTH
 		if(src.special_s >= 7 && src.special_s < 9)
 			ADD_TRAIT(src, TRAIT_QUICK_CARRY, "quick-carry")
-		// Super agile and not THICC
 		if(src.special_s >= 9)
 			ADD_TRAIT(src, TRAIT_QUICKER_CARRY, "quicker-carry")
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -32,6 +32,10 @@
 		if(src.special_s >= 9)
 			ADD_TRAIT(src, TRAIT_QUICKER_CARRY, "quicker-carry")
 
+		// PERCEPTION
+		if(src.special_p >= 7)
+			ADD_TRAIT(src, TRAIT_NIGHT_VISION, "night_vision")
+
 		// ENDURANCE
 		src.maxHealth += (src.special_e*3)
 		src.health += (src.special_e*3)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -26,6 +26,13 @@
 		// This is the primary spot for all stat based special bonuses that are passive.
 		// Primarily because its easy to debug this in round. -Possum
 
+		// STRENGTH
+		if(src.special_s >= 7 && src.special_s < 9)
+			ADD_TRAIT(src, TRAIT_QUICK_CARRY, "quick-carry")
+		// Super agile and not THICC
+		if(src.special_s >= 9)
+			ADD_TRAIT(src, TRAIT_QUICKER_CARRY, "quicker-carry")
+
 		// ENDURANCE
 		src.maxHealth += (src.special_e*3)
 		src.health += (src.special_e*3)
@@ -53,6 +60,8 @@
 		// AGILITY
 		// The below line affects movement speed.
 		update_special_speed((5-src.special_a)/20)
+		if(src.special_a >= 9)
+			ADD_TRAIT(src, TRAIT_NOSLIPALL, "noslip_all")
 
 		// Basic leap
 		if(src.special_a >= 7 && src.special_a < 9)
@@ -92,6 +101,9 @@
 		// Int/End/Str - Represents a smart and strong person brute forcing PA training.
 		if(src.special_i >= 9 && src.special_e >= 7 && src.special_s >= 7)
 			ADD_TRAIT(src, TRAIT_PA_WEAR, "pa_wear")
+		// Int/Per/Agi - Someone who is smart, perceptive, and good with their hands can cut down on crafting time.
+		if(src.special_i >= 5 && src.special_e >= 5 && src.special_s >= 5)
+			ADD_TRAIT(src, TRAIT_QUICK_BUILD, "quick-build")
 
 
 		SPECIAL_SET = TRUE


### PR DESCRIPTION
-The second form of razorclaw armor now has DT 15. 
-Fixed an issue with nuka ice adding twice its effect for nuka lover. 
-Having 7+ endurance gives an insanely slow but constant regeneration of 0.02 brute/fire/tox regen. +9 End ups this to 0.04.
-Having Agility 9 now gives you immunity to slipping. 
-Strength 7 and 9 give quick carry and quicker carry traits. 
-Having Int/Per/Agi 5 or greater gives you the quick build trait. 
-Raiders can now only wear raider named items in the uniform, gloves, shoe, and head slot. Handwraps, crude medical gloves, and some items like jackboots can be worn without the word 'raider' in the name. Accessories and eyeglasses are not affected.
-Raider ganger load out changed to raider bomber and given blastmaster armor to replace the powder ganger armor. This is a direct buff, as blastmaster armor is heavy armor and has DT 5.
-Removed night vision as a perk since it was never taken by most and added it as a passive perk for perception 7 or greater.
-Perception 7 allows you to ignore bear traps. Perception 9 lets you ignore bola cuffing.

For those who are thinking this is some pretty serious buffs it is actually pretty deceptively mid to low end in terms of buffs. Quick carry, quicker carry, and quick build just speed up some very specific actions and thus are so niche they can't really be justified as becoming their own perks, so instead they were added here. Immunity to all forms of slippings sounds great on paper but is actually rather deceptively bad. Firstly, the only form of effective slipping is water and soap outside those who have chemistry knowledge and access to a chem machine, secondly the former can be denied by wearing a certain pair of very easy to obtain shoes (fuck u legion mains) and the latter can be negated by the same shoes or simply dodged.

The second seemingly powerful boost is the natural regeneration for high endurance. On the surface this looks good BUT testing showed that after 8 minutes of waiting, the max effect of 9 endurance only healed 10 brute damage. If I somehow had brute, burn, AND toxin this would technically be 30 healed after 8 minutes, but that pales in comparison to just... using a stimpak. I wouldn't even say at this rate that its supplemental but I wanted to keep it on the very low side to avoid it being too good. If I was incredibly fucked up, out of meds, and all I had was time I could eventually get out of crit when combined with sleeping.

Finally, you have the raider changes. It occurred to me that if I was a particularly savvy raider I could disguise myself as a wastelander by removing my armor and making sure my uniform was a generic wastelander outfit. This goes against how I envisioned the raider play style and thus these new locks are there to prevent that. Sneaky beaky stealth ops are for the enclave, direct obvious violence is what raiders are for. This will also keep raiders consistent, style wise, and be better in general for RP and PvP. 

The changes to perception are to reward the stat a little more, as is, its not particularly great and I did not want to further nerf shooting just to make it a more viable stat. Now it has some good support and defensive side grades, as trap dodging is a pretty good boost given how meta leg cuffing is in combat.

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.