### PR TITLE
Ammo Quick-Kits, Revert Belt/Pouch Salt PR from Upstream, Some minor adjustments, Special Integration to Medical

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -188,12 +188,7 @@ GLOBAL_LIST_INIT(trash_clothing, list(
 ))
 
 GLOBAL_LIST_INIT(trash_ammo, list(
-	/obj/item/ammo_box/a762mmbox/sport = 3,
-	/obj/item/ammo_box/a556mmbox/sport = 3,
-	/obj/item/ammo_box/magazine/m10mm = 1,
-	/obj/item/ammo_box/magazine/zipgun = 3,
-	/obj/item/ammo_casing/shotgun/buckshot = 2,
-	/obj/item/ammo_box/a357box = 3,
+	/obj/item/ammo_crafting_kit
 ))
 
 GLOBAL_LIST_INIT(trash_chem, list(

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -99,6 +99,9 @@
 	if(M.stat == DEAD)
 		to_chat(user, "<span class='notice'> [M] is dead. You can not help [M.p_them()]!</span>")
 		return
+	// Sanity check, basically resets the heal to prevent stat/bonus stacking. A hack, but hey, it works.
+	heal_brute = initial(heal_brute)
+	stat_bonus_total  = 0
 	if(isanimal(M))
 		var/mob/living/simple_animal/critter = M
 		if (!(critter.healable))
@@ -117,7 +120,6 @@
 		if(user.special_c >= 6 && user.special_i >= 6)
 			stat_bonus_total = user.special_c + user.special_i
 			heal_brute += stat_bonus_total
-			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 	to_chat(user, "<span class='notice'>You can't heal [M] with the \the [src]!</span>")
@@ -297,13 +299,16 @@
 	if(M.stat == DEAD)
 		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")
 		return
+	// Sanity check, basically resets the heal to prevent stat/bonus stacking. A hack, but hey, it works.
+	heal_brute = initial(heal_brute)
+	stop_bleeding = initial(stop_bleeding)
+	stat_bonus_total  = 0
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
 			stat_bonus_total = round((user.special_c + user.special_i) / 3)
 			heal_brute += stat_bonus_total
 			stop_bleeding += stat_bonus_total
-			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, 0)
 	if(isanimal(M))
 		var/mob/living/simple_animal/critter = M
@@ -347,13 +352,16 @@
 	if(M.stat == DEAD)
 		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")
 		return
+	// Sanity check, basically resets the heal to prevent stat/bonus stacking. A hack, but hey, it works.
+	heal_burn = initial(heal_burn)
+	flesh_regeneration = initial(flesh_regeneration)
+	stat_bonus_total  = 0
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
 			stat_bonus_total = round((user.special_c + user.special_i) / 3)
 			heal_burn += stat_bonus_total
 			flesh_regeneration += stat_bonus_total
-			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 
@@ -426,13 +434,16 @@
 	if(M.stat == DEAD)
 		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")
 		return
+	// Sanity check, basically resets the heal to prevent stat/bonus stacking. A hack, but hey, it works.
+	heal_burn = initial(heal_burn)
+	flesh_regeneration  = initial(flesh_regeneration)
+	stat_bonus_total  = 0
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
 			stat_bonus_total = round((user.special_c + user.special_i) / 3)
 			heal_burn += stat_bonus_total
 			flesh_regeneration += stat_bonus_total
-			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 
@@ -557,13 +568,16 @@
 	amount = 5
 
 /obj/item/stack/medical/poultice/heal(mob/living/M, mob/user)
+	// Sanity check, basically resets the heal to prevent stat/bonus stacking. A hack, but hey, it works.
+	heal_brute = initial(heal_brute)
+	heal_burn = initial(heal_burn)
+	stat_bonus_total  = 0
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
 			stat_bonus_total = round((user.special_c + user.special_i) / 3)
 			heal_brute += stat_bonus_total
 			heal_burn += stat_bonus_total
-			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	return ..()
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -26,6 +26,8 @@
 	var/sanitization
 	/// How much we add to flesh_healing for burn wounds on application
 	var/flesh_regeneration
+	//SPECIAL integration
+	var/stat_bonus_total
 
 /obj/item/stack/medical/attack(mob/living/M, mob/user)
 	. = ..()
@@ -113,7 +115,9 @@
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
-			heal_brute += user.special_c + user.special_i
+			stat_bonus_total = user.special_c + user.special_i
+			heal_brute += stat_bonus_total
+			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 	to_chat(user, "<span class='notice'>You can't heal [M] with the \the [src]!</span>")
@@ -296,8 +300,10 @@
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
-			heal_brute += round(user.special_c/3) + round(user.special_i/3)
-			stop_bleeding += round(user.special_c/3) + round(user.special_i/3)
+			stat_bonus_total = round((user.special_c + user.special_i) / 3)
+			heal_brute += stat_bonus_total
+			stop_bleeding += stat_bonus_total
+			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, 0)
 	if(isanimal(M))
 		var/mob/living/simple_animal/critter = M
@@ -344,8 +350,10 @@
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
-			heal_burn += round(user.special_c/3) + round(user.special_i/3)
-			flesh_regeneration += round(user.special_c/3) + round(user.special_i/3)
+			stat_bonus_total = round((user.special_c + user.special_i) / 3)
+			heal_burn += stat_bonus_total
+			flesh_regeneration += stat_bonus_total
+			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 
@@ -421,8 +429,10 @@
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
-			heal_burn += user.special_c + user.special_i
-			flesh_regeneration += round(user.special_c/3) + round(user.special_i/3)
+			stat_bonus_total = round((user.special_c + user.special_i) / 3)
+			heal_burn += stat_bonus_total
+			flesh_regeneration += stat_bonus_total
+			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 
@@ -550,8 +560,10 @@
 	if(iscarbon(M))
 		//SPECIAL integration
 		if(user.special_c >= 6 && user.special_i >= 6)
-			heal_brute += round(user.special_c/3) + round(user.special_i/3)
-			heal_burn += round(user.special_c/3) + round(user.special_i/3)
+			stat_bonus_total = round((user.special_c + user.special_i) / 3)
+			heal_brute += stat_bonus_total
+			heal_burn += stat_bonus_total
+			stat_bonus_total = 0 //sanity
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	return ..()
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -111,6 +111,9 @@
 		M.heal_bodypart_damage((heal_brute/2))
 		return TRUE
 	if(iscarbon(M))
+		//SPECIAL integration
+		if(user.special_c >= 6 && user.special_i >= 6)
+			heal_brute += user.special_c + user.special_i
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 	to_chat(user, "<span class='notice'>You can't heal [M] with the \the [src]!</span>")
@@ -291,6 +294,10 @@
 		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")
 		return
 	if(iscarbon(M))
+		//SPECIAL integration
+		if(user.special_c >= 6 && user.special_i >= 6)
+			heal_brute += round(user.special_c/3) + round(user.special_i/3)
+			stop_bleeding += round(user.special_c/3) + round(user.special_i/3)
 		return heal_carbon(M, user, heal_brute, 0)
 	if(isanimal(M))
 		var/mob/living/simple_animal/critter = M
@@ -335,6 +342,10 @@
 		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")
 		return
 	if(iscarbon(M))
+		//SPECIAL integration
+		if(user.special_c >= 6 && user.special_i >= 6)
+			heal_burn += round(user.special_c/3) + round(user.special_i/3)
+			flesh_regeneration += round(user.special_c/3) + round(user.special_i/3)
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 
@@ -408,6 +419,10 @@
 		to_chat(user, "<span class='warning'>[M] is dead! You can not help [M.p_them()].</span>")
 		return
 	if(iscarbon(M))
+		//SPECIAL integration
+		if(user.special_c >= 6 && user.special_i >= 6)
+			heal_burn += user.special_c + user.special_i
+			flesh_regeneration += round(user.special_c/3) + round(user.special_i/3)
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	to_chat(user, "<span class='warning'>You can't heal [M] with \the [src]!</span>")
 
@@ -533,6 +548,10 @@
 
 /obj/item/stack/medical/poultice/heal(mob/living/M, mob/user)
 	if(iscarbon(M))
+		//SPECIAL integration
+		if(user.special_c >= 6 && user.special_i >= 6)
+			heal_brute += round(user.special_c/3) + round(user.special_i/3)
+			heal_burn += round(user.special_c/3) + round(user.special_i/3)
 		return heal_carbon(M, user, heal_brute, heal_burn)
 	return ..()
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -7,7 +7,6 @@
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
-	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("whipped", "lashed", "disciplined")
 	max_integrity = 300
 	var/content_overlays = FALSE //If this is true, the belt will gain overlays based on what it's holding

--- a/code/modules/fallout/obj/explosives.dm
+++ b/code/modules/fallout/obj/explosives.dm
@@ -4,7 +4,8 @@
 
 /obj/item/bottlecap_mine
 	name = "bottlecap mine"
-	desc = "It has an adjustable timer. It can explode in 5 seconds after activating."
+	desc = "It has an adjustable timer. It can explode in 5 seconds after activating. The motion sensor suggests nobody \
+	will be able to avoid tripping it once its active."
 	w_class = 2
 	icon = 'icons/fallout/objects/crafting.dmi'
 	icon_state = "capmine"
@@ -251,6 +252,9 @@
 
 /obj/item/mine/proc/triggermine(mob/victim)
 	if(triggered)
+		return
+	if(victim.special_p >= 8)
+		to_chat(victim, "<span class='danger'>You narrowly avoid setting off the [src]!</span>")
 		return
 	visible_message("<span class='danger'>[victim] sets off [icon2html(src, viewers(src))] [src]!</span>")
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread

--- a/code/modules/fallout/storage/pouch.dm
+++ b/code/modules/fallout/storage/pouch.dm
@@ -1,7 +1,7 @@
 /obj/item/storage/pouch
 	name = "SPECIALIZED POUCH TEMPLATE"
 	desc = "You're not supposed to see this."
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_POCKET
 
 /obj/item/storage/pouch/ammo
@@ -33,14 +33,12 @@
 	desc = "A pouch designed for storing basic tools."
 	icon_state = "pouch_utility"
 	component_type = /datum/component/storage/concrete/pouch/tool
-	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/pouch/medical
 	name = "medical pouch"
 	desc = "A pouch designed for storing basic medical items."
 	icon_state = "pouch_medical"
 	component_type = /datum/component/storage/concrete/pouch/medical
-	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/pouch/medical/full/PopulateContents()
 	new /obj/item/reagent_containers/hypospray/medipen/stimpak(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -212,6 +212,8 @@
 			power_throw++
 		if(pulling && grab_state >= GRAB_NECK)
 			power_throw++
+		if(src.special_s >= 7)
+			power_throw++
 		visible_message("<span class='danger'>[src] throws [thrown_thing][power_throw ? " really hard!" : "."]</span>", \
 						"<span class='danger'>You throw [thrown_thing][power_throw ? " really hard!" : "."]</span>")
 		log_message("has thrown [thrown_thing] [power_throw ? "really hard" : ""]", LOG_ATTACK)

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -45,6 +45,7 @@
 				new /obj/item/ammo_box/c10mm/improvised(user.loc)
 			else
 				new /obj/item/ammo_box/c10mm/improvised(user.loc)
+			qdel(src)
 		if(".357")
 			if(user.special_l * 10 && user.special_l >= 3)
 				new /obj/item/ammo_box/a357box(user.loc)

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -1,5 +1,80 @@
 //In this document: Ammo boxes, speed loaders, stripper clips.
 
+////////////////////
+//    AMMO KIT    //
+////////////////////
+/obj/item/ammo_crafting_kit
+	name = "Handloader Quick-Kit"
+	desc = "A tin can filled with lead, gunpowder, and some crappy tools that could be used to make some basic handloads. \
+	Someone smart could easily make the most of this kit. Someone lucky could make something great."
+	icon = 'icons/fallout/objects/guns/ammo.dmi'
+	icon_state = "BBbox"
+
+/obj/item/ammo_crafting_kit/attack_self(mob/user)
+	var/list/choices = list("shotgun", ".38", "10mm", ".357", ".44", ".45")
+	var/choice = input("Choose an ammo type:") in choices
+	switch(choice)
+		if(null)
+			return 0
+		if("shotgun")
+			if(user.special_l * 10 && user.special_l >= 3)
+				new /obj/item/ammo_box/shotgun/buck(user.loc)
+				new /obj/item/ammo_box/shotgun/buck(user.loc)
+			else if (user.special_i >= 6)
+				new /obj/item/ammo_box/shotgun/improvised(user.loc)
+				new /obj/item/ammo_box/shotgun/improvised(user.loc)
+			else
+				new /obj/item/ammo_box/shotgun/improvised(user.loc)
+			qdel(src)
+		if(".38")
+			if(user.special_l * 10 && user.special_l >= 3)
+				new /obj/item/ammo_box/c38box(user.loc)
+				new /obj/item/ammo_box/c38box(user.loc)
+			else if (user.special_i >= 6)
+				new /obj/item/ammo_box/c38box/improvised(user.loc)
+				new /obj/item/ammo_box/c38box/improvised(user.loc)
+			else
+				new /obj/item/ammo_box/c38box/improvised(user.loc)
+			qdel(src)
+		if("10mm")
+			if(user.special_l * 10 && user.special_l >= 3)
+				new /obj/item/ammo_box/c10mm(user.loc)
+				new /obj/item/ammo_box/c10mm(user.loc)
+			else if (user.special_i >= 6)
+				new /obj/item/ammo_box/c10mm/improvised(user.loc)
+				new /obj/item/ammo_box/c10mm/improvised(user.loc)
+			else
+				new /obj/item/ammo_box/c10mm/improvised(user.loc)
+		if(".357")
+			if(user.special_l * 10 && user.special_l >= 3)
+				new /obj/item/ammo_box/a357box(user.loc)
+				new /obj/item/ammo_box/a357box(user.loc)
+			else if (user.special_i >= 6)
+				new /obj/item/ammo_box/a357box/improvised(user.loc)
+				new /obj/item/ammo_box/a357box/improvised(user.loc)
+			else
+				new /obj/item/ammo_box/a357box/improvised(user.loc)
+			qdel(src)
+		if(".44")
+			if(user.special_l * 10 && user.special_l >= 3)
+				new /obj/item/ammo_box/m44box(user.loc)
+				new /obj/item/ammo_box/m44box(user.loc)
+			else if (user.special_i >= 6)
+				new /obj/item/ammo_box/m44box/improvised(user.loc)
+				new /obj/item/ammo_box/m44box/improvised(user.loc)
+			else
+				new /obj/item/ammo_box/m44box/improvised(user.loc)
+			qdel(src)
+		if(".45")
+			if(user.special_l * 10 && user.special_l >= 3)
+				new /obj/item/ammo_box/c45(user.loc)
+				new /obj/item/ammo_box/c45(user.loc)
+			else if (user.special_i >= 6)
+				new /obj/item/ammo_box/c45/improvised(user.loc)
+				new /obj/item/ammo_box/c45/improvised(user.loc)
+			else
+				new /obj/item/ammo_box/c45/improvised(user.loc)
+			qdel(src)
 
 ////////////////////
 //AMMUNITION BOXES//

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
@@ -32,10 +32,18 @@
 
 /datum/design/seclite
 	name = "Seclite"
-	id = "flashlight"
+	id = "seclite"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
 	build_path = /obj/item/flashlight/seclite
+	category = list("initial","Tools")
+
+/datum/design/lantern
+	name = "Lantern"
+	id = "lantern"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
+	build_path = /obj/item/flashlight/lantern
 	category = list("initial","Tools")
 
 /datum/design/metaldetector

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
@@ -30,7 +30,7 @@
 	build_path = /obj/item/flashlight
 	category = list("initial","Tools")
 
-/datum/design/seclite
+/datum/design/seclite_public
 	name = "Seclite"
 	id = "seclite"
 	build_type = AUTOLATHE
@@ -38,7 +38,7 @@
 	build_path = /obj/item/flashlight/seclite
 	category = list("initial","Tools")
 
-/datum/design/lantern
+/datum/design/lantern_light
 	name = "Lantern"
 	id = "lantern"
 	build_type = AUTOLATHE

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
@@ -30,6 +30,14 @@
 	build_path = /obj/item/flashlight
 	category = list("initial","Tools")
 
+/datum/design/seclite
+	name = "Seclite"
+	id = "flashlight"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
+	build_path = /obj/item/flashlight/seclite
+	category = list("initial","Tools")
+
 /datum/design/metaldetector
 	name = "Metal Detector"
 	id = "metaldetector"

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
@@ -32,7 +32,7 @@
 
 /datum/design/seclite_public
 	name = "Seclite"
-	id = "seclite"
+	id = "seclite_public"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
 	build_path = /obj/item/flashlight/seclite


### PR DESCRIPTION
-Landmines can be dodged if you have perception 8 or higher.
-Updated the bottlecap description to reflect that you can't dodge it like other landmines. This is a restriction due to how bottlecap mines have a snowflake method for detecting mobs near it rather than crossing it.
-Strength 7+ or higher alters some strike text for throwing now, purely cosmetic.
-Autolathes can now produce seclites, to give a blue light alternate option and a way to get gun attachment flashlights.
-Also added lanterns, as they are a functionally different version of flashlights, to give more options.
-All trash ammo spawns now produce an ammo quick-kit, which allows you to create low tier ammo. If you have high luck you might create full quality ammo, if you have 6 intelligence, you create 2 bags of reloaded ammo. If you have 1-2 luck, fail the luck check, and 5 or less intelligence, you only get 1 bag of reloads of your choice.
-Reverted the bulky tag that was placed on pouches and belts by an upstream, which did this as a salt PR because someone had too much equipment at one point and killed a developer.
-Players with Charisma 6 AND Intelligence 6 will add there scores /3 to all healing steps with medical items. This means healing for players with the right stats will increase by 4-6. Having either stat below 6 negates this bonus healing effect.

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
