### PR TITLE
Job Rework for New Map

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -140,8 +140,12 @@
 #define WASTELAND		(1<<8)
 
 #define F13WASTELANDER	(1<<0)
-#define F13VIGILANTE	(1<<3)
-#define F13ADMINBOOS	(1<<4)
+#define F13NCRSCOUT		(1<<1)
+#define F13LEGIONRIMOR	(1<<2)
+#define F13BOSSKNIGHT	(1<<3)
+#define F13KHANRUNNER	(1<<4)
+#define F13VIGILANTE	(1<<5)
+#define F13ADMINBOOS	(1<<6)
 
 #define RAIDER			(1<<9)
 

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -75,15 +75,15 @@
 #define EXP_TYPE_VAULT			"Vault"
 #define EXP_TYPE_BROTHERHOOD	"BoS"
 #define EXP_TYPE_NCR			"NCR"
-#define EXP_TYPE_BIGHORN		"Waypoint"
+#define EXP_TYPE_BIGHORN		"Westford Town"
 #define EXP_TYPE_LEGION			"Legion"
-#define EXP_TYPE_WASTELAND		"Wasteland"
+#define EXP_TYPE_WASTELAND		"Independent"
 #define EXP_TYPE_ENCLAVE		"Enclave"
 #define EXP_TYPE_NCRCOMMAND     "NCRCommand"
 #define EXP_TYPE_RANGER         "Ranger"
 #define EXP_TYPE_SCRIBE         "Scribe"
 #define EXP_TYPE_DECANUS        "Decanus"
-#define EXP_TYPE_FOLLOWERS		"FoA"
+#define EXP_TYPE_FOLLOWERS		"Westford Medical"
 #define EXP_TYPE_KHAN			"Great Khans"
 //Flags in the players table in the db
 #define DB_FLAG_EXEMPT 							(1<<0)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -174,7 +174,7 @@
 	channels = list(RADIO_CHANNEL_TOWN = 1)
 
 /obj/item/encryptionkey/headset_den
-	name = "den radio encryption key"
+	name = "raider radio encryption key"
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_DEN = 1)
 

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -543,8 +543,8 @@
 //Followers
 
 /obj/item/clothing/suit/hooded/followerlight
-	name = "\improper Followers labcoat"
-	desc = "A well-kept labcoat with the insignia of the followers stitched onto the back and shoulders, provides excellent protection from chemical hazards and radiation."
+	name = "\improper westford labcoat"
+	desc = "A well-kept labcoat with the insignia of westford medical stitched onto the back and shoulders, provides excellent protection from chemical hazards and radiation."
 	icon = 'icons/fallout/clothing/suits_cosmetic.dmi'
 	hoodtype = /obj/item/clothing/head/hooded/followerlight
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_cosmetic.dmi'
@@ -554,7 +554,7 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small
 
 /obj/item/clothing/head/hooded/followerlight
-	name = "\improper Followers labcoat hood"
+	name = "\improper labcoat hood"
 	icon_state = "follower_light"
 	icon = 'icons/fallout/clothing/hats.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'

--- a/code/modules/fallout/equipment/headsets.dm
+++ b/code/modules/fallout/equipment/headsets.dm
@@ -173,7 +173,7 @@
 
 /obj/item/radio/headset/headset_den
 	name = "den radio headset"
-	desc = "This is used by the den.\nUse .j To access the Den channel."
+	desc = "This is used by raiders.\nUse .j To access the raider channel."
 	icon_state = "mine_headset"
 	keyslot = new /obj/item/encryptionkey/headset_den
 

--- a/code/modules/fallout/start_landmarks.dm
+++ b/code/modules/fallout/start_landmarks.dm
@@ -309,6 +309,22 @@
 	name = "Wastelander"
 	icon_state = "Wastelander"
 
+/obj/effect/landmark/start/f13/f13ncrscout
+	name = "NCR Scout"
+	icon_state = "Wastelander"
+
+/obj/effect/landmark/start/f13/f13legion_explorer
+	name = "Legion Rimor"
+	icon_state = "Wastelander"
+
+/obj/effect/landmark/start/f13/f13brotherhood_initiate
+	name = "Brotherhood Scout-Knight"
+	icon_state = "Wastelander"
+
+/obj/effect/landmark/start/f13/f13khan_runner
+	name = "Great Khan Runner"
+	icon_state = "Wastelander"
+
 /obj/effect/landmark/start/f13/raider
 	name = "Raider"
 	icon_state = "Raider"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -62,7 +62,7 @@ Elder
 	exp_requirements = 0
 
 	total_positions = 0
-	spawn_positions = 1
+	spawn_positions = 0
 
 	outfit = /datum/outfit/job/bos/f13elder
 
@@ -99,8 +99,8 @@ Head Paladin
 	title = "Paladin Commander"
 	flag = F13SENTINEL
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the acting field commander on behalf of the Chicago chapter. You are a veteran of many battles and sorties in pursuit of Brotherhood goals; your only weakness may just be your hubris. Your main goals are the protection of your brothers, initiating Juniors in the caste, diplomacy and trade."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -180,8 +180,8 @@ Proctor
 	title = "Head Scribe"
 	flag = F13HEADSCRIBE
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You head the scientific, diplomatic and exploratory nature of this expedition at the behest of the Council of Elders. While all the castes look up to you in moments of need for objectives, tasks, and the way forward - you must ensure that decisions on situations requiring a fist must be made in accordance with you Senior Paladins and Senior Knights. You are the lead medical and engineering expert of the chapter, and must not head out without escort."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -412,8 +412,8 @@ Paladin
 /datum/job/bos/f13paladin
 	title = "Paladin"
 	flag = F13PALADIN
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer to the Paladin Commander, and by extension - the Head Scribe for issues regarding technology aquisition. Be the chapter's shock infantry, and utilize your armour to its fullest capacity. Highly trained from experience as a knight - you are to take field command in the absence of a Senior Paladin. You may also finalize trade and diplomatic decisions in the absence of a superior. You are also required to train Squires, so that they may one day become Paladins themselves."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -503,8 +503,8 @@ Senior Scribe
 /datum/job/bos/f13seniorscribe
 	title = "Senior Scribe"
 	flag = F13SENIORSCRIBE
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer to the Head Scribe. You are an experienced scientific expert in the fields of medical and engineering technology. Guide your scribes, conduct trade by the side of the Paladins, and ensure your bunker is in the best shape possible. You may also take up the duties of a Field Scribe, with an escort - and may travel close to the chapter bunker to collect salvage and medical herbs if needed."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -585,8 +585,8 @@ Scribe
 /datum/job/bos/f13scribe
 	title = "Scribe"
 	flag = F13SCRIBE
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a Scribe - tasked with researching and reverse-engineering recovered technologies from the old world, while maintaining your chapter's. You may also be trained in medical or engineering technologies - and can conduct trade by the side of the Paladin caste. You may also take up the duties of a Field Scribe, with an escort - and may travel close to the chapter bunker to collect salvage and medical herbs if needed."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Ethical experimentation and research. Maintenance and crafting."
@@ -670,8 +670,8 @@ Scribe
 /datum/job/bos/f13seniorknight // Is now Senior Knight again. Yep.
 	title = "Senior Knight"
 	flag = F13SENIORKNIGHT
-	total_positions = 2
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the senior-most member of your caste in the chapter. Experienced in the fields of combat, reconnaissance and defense; you must lead your caste to victory. Assist Paladins, prepare defense. You are also the one who heads the internal security of the bunker - ensuring personnel are adhering to the Codex, and squashing insubordination."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -747,8 +747,8 @@ Knight
 /datum/job/bos/f13knight // Back to being knight again. Yippee.
 	title = "Knight"
 	flag = F13KNIGHT
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the veritable lifeblood of your chapter. Versatile, adaptable and hopefully, dangerous to the chapter's enemies. Your prime duties include ensuring the defense of the chapter, assisting Paladins in expeditions, and serving as scouts. You may also train and take charge of Initiates."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -840,8 +840,8 @@ Squire
 /datum/job/bos/f13squire
 	title = "Squire"
 	flag = F13SQUIRE
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are an Initiate that showed enough promise during training to be made a Squire, and one day, a Paladin. Listen to the Paladins, follow their orders, and let them guide you. They will lead you into your new life. You are NOT above Initiate. Do not order them around."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -885,8 +885,8 @@ Initiate
 /datum/job/bos/f13initiate
 	title = "Initiate"
 	flag = F13INITIATE
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "Either recently inducted or born into the Brotherhood, you have since proven yourself worthy of assignment to the Chapter. You are to assist your superiors and receive training how they deem fit. You are NEVER allowed to leave the bunker without the direct supervision of a superior; doing so may result in exile or transferrence back the Valley."
 	forbids = "The Brotherhood of Steel Expects: Obeying superiors and respecting the Chain that Binds to a degree. Collection and safeguarding of HARMFUL technology from the wasteland. Expanding and making relations only at the benefit of the chapter. Experimentation, research and innovation."
 	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
@@ -965,8 +965,8 @@ Off-Duty
 /datum/job/bos/f13offdutybos
 	title = "BoS Off-Duty"
 	flag = F13OFFDUTYBOS
-	total_positions = 7
-	spawn_positions = 7
+	total_positions = 0
+	spawn_positions = 0
 	description = "While off-duty, you are relieved of both your duties and your authority. You are not required to participate in any routine duties of the bunker, and you may spend your time doing whatever you please, within reason."
 	supervisors = "your superior rank."
 	enforces = "You are not permited to leave the base. You are a non-combatant. You cannot join any raids or battles on the surface. You cannot not run dungeons."

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -38,8 +38,8 @@
 	title = "Khan Armorer"
 	flag = F13KHANSMITH
 	faction = FACTION_KHAN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the armorer, a mixture of an Electrician and Engineer through trial-and-error. Maintain the camp and assist the Senior Enforcer when possible."
 	enforces = "You have control over the forge, a valuable asset in maintaining your presence in the area."
 	supervisors = "the Senior Enforcer"
@@ -57,8 +57,8 @@
 	title = "Khan Senior Enforcer"
 	flag = F13KHANSEN
 	faction = FACTION_KHAN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a Khan, atop being the senior of all within this camp. Maintain some manner of control and assure the Chemist doesn't blow their hands off."
 	supervisors = "the Senior Enforcer"
 	selection_color = "#ff915e"
@@ -77,8 +77,8 @@
 	title = "Khan Enforcer"
 	flag = F13KHAN
 	faction = FACTION_KHAN
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a Khan, a member of the local band that the Chief has sent to scout these lands. Listen to the Chemist, and assure you've a steady supply of caps for the Chief."
 	supervisors = "the Senior Enforcer"
 	selection_color = "#ff915e"
@@ -97,8 +97,8 @@
 	title = "Khan Chemist"
 	flag = F13KHANCHEMIST
 	faction = FACTION_KHAN
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a Chemist, one of the few Khans present in this camp that can produce those sweet, sweet chems. Keep them flowing and assure a supply of caps, so you can send them back to the Chief."
 	enforces = "You have control over the lab, a valuable asset in generating profit."
 	supervisors = "the Senior Enforcer"

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -143,8 +143,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	flag = F13ORATOR
 	supervisors = "Centurion"
 	selection_color = "#ffdddd"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13orator
 	display_order = JOB_DISPLAY_ORDER_ORATOR
 	access = list(ACCESS_LEGION, ACCESS_CHANGE_IDS, ACCESS_LEGION_COMMAND, ACCESS_LEGION_SLAVE)
@@ -189,8 +189,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	flag = F13PRIESTESS
 	supervisors = "Centurion"
 	selection_color = "#ffdddd"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	outfit = /datum/outfit/job/CaesarsLegion/f13priestess
 	display_order = JOB_DISPLAY_ORDER_PRIESTESS
 	access = list(ACCESS_LEGION, ACCESS_LEGION_COMMAND, ACCESS_LEGION_SLAVE)
@@ -246,8 +246,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 	title = "Legion Centurion"
 	flag = F13CENTURION
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the camp commander and strongest soldier. Use your officers, the Decanii, to delegate tasks, make sure you lead and give orders. Take no disrespect, you are the dominus. If you prove a fool or weak, expect to be dispatched by a stronger subordinate."
 	supervisors = "the Legate"
 	selection_color = "#ffdddd"
@@ -336,8 +336,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/f13decanvet
 	title = "Legion Veteran Decanus"
 	flag = F13DECANVET
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Centurion, his second in command. Lead the camp, ensure its defended, keep track of the Explorers and use your veterans to their full potential."
 	supervisors = "the Centurion"
 	display_order = JOB_DISPLAY_ORDER_DECANVET
@@ -428,8 +428,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/f13decan
 	title = "Legion Prime Decanus"
 	flag = F13DECAN
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "A experienced officer, often commanding the camp. Give orders, lead patrols."
 	supervisors = "the Veteran Decanus and the Centurion"
 	display_order = JOB_DISPLAY_ORDER_DECAN
@@ -506,8 +506,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/f13decanrec
 	title = "Legion Recruit Decanus"
 	flag = F13DECANREC
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "The junior officer, you must train the recruits and test them, and if a suicide charge is needed, lead them to a glorious death."
 	supervisors = "the Prime/Veteran Decanus and the Centurion"
 	display_order = JOB_DISPLAY_ORDER_DECANREC
@@ -577,8 +577,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/f13vexillarius
 	title = "Legion Vexillarius"
 	flag = F13VEXILLARIUS
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a Veteran of proven bravery. When not fighting, relay orders from the commander and act as a bodyguard."
 	supervisors = "the Veteran Decanus and Centurion"
 	display_order = JOB_DISPLAY_ORDER_VEXILLARIUS
@@ -656,8 +656,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/f13explorer
 	title = "Legion Explorer"
 	flag = F13EXPLORER
-	total_positions = 2
-	spawn_positions = 3
+	total_positions = 0
+	spawn_positions = 0
 	description = "Scout the area, secure key points, but do not ignore orders or wordlessly die some place. A good explorer helps his unit by taking initiative and helping the commander without needing micro-managment."
 	supervisors = "the Veteran Decanus and Centurion must be obeyed, and as always, respect must be given to other Decanus. You are not a officer, but you are a specialist."
 	display_order = JOB_DISPLAY_ORDER_EXPLORER
@@ -729,8 +729,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/vetlegionnaire
 	title = "Veteran Legionary"
 	flag = F13VETLEGIONARY
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 0
+	spawn_positions = 0
 	description = "A hardened warrior, obeying the orders from the Decanus and Centurion is second nature, as is fighting the profligates. If no officers are present, make sure the younger warriors act like proper Legionaires."
 	supervisors = "the Decani and Centurion"
 	display_order = JOB_DISPLAY_ORDER_VETLEGIONARY
@@ -804,8 +804,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/f13legionary
 	title = "Prime Legionary"
 	flag = F13LEGIONARY
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 0
+	spawn_positions = 0
 	description = "A front line soldier who has shown ability to obey and fought in some battles. The Legions muscle, the young men who will build the future with their own blood and sacrifice, for Caesar."
 	supervisors = "the Decani and Centurion"
 	display_order = JOB_DISPLAY_ORDER_LEGIONARY
@@ -873,8 +873,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/Legionnaire/f13recleg
 	title = "Recruit Legionary"
 	flag = F13RECRUITLEG
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	description = "You have recently been transfered or inducted into The Legion. You have minimal training, and are expected to follow every whim of the Decani and your Centurion. Respect every soldier of higher rank."
 	supervisors = "the Decani and Centurion."
 	display_order = JOB_DISPLAY_ORDER_RECRUITLEG
@@ -943,8 +943,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/immune
 	title = "Legion Camp Follower"
 	flag = F13IMMUNE
-	total_positions = 7
-	spawn_positions = 7
+	total_positions = 0
+	spawn_positions = 0
 	description = "An Immune is a Legionary or free citizen temporarily assigned to keeping the camp in order, according to their tasking on any given week."
 	enforces = "You may leave the base, but you are not allowed to antagonize other factions or scavenge. You are a non-combatant. You cannot join any raids or battles on the surface. You cannot run dungeons."
 	supervisors = "the Centurion."
@@ -978,8 +978,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/f13campfollower	// Extra materials, Blueprints
 	title = "Legion Forgemaster"
 	flag = F13CAMPFOLLOWER
-	total_positions = 1
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "The Forgemaster makes weapons of all sorts and upgrades them, keeping order in the Forge and makes sure the camp is defended."
 	supervisors = "the Centurion."
 	display_order = JOB_DISPLAY_ORDER_CAMPFOLLOWER
@@ -1025,8 +1025,8 @@ Discuss balance and documentation changes with Dragonfruits#1913 or forward them
 /datum/job/CaesarsLegion/auxilia
 	title = "Legion Auxilia"
 	flag = F13AUXILIA
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 0
+	spawn_positions = 0
 	description = "A non-combat position in the Legion for free citizens who perform tasks that need special training, such as surgery. They are loyal to the Legion even if they are not treated as equals to warriors."
 	supervisors = "the Centurion"
 	display_order = JOB_DISPLAY_ORDER_AUXILIA
@@ -1214,8 +1214,8 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 /datum/job/CaesarsLegion/Legionnaire/f13venator
 	title = "Legion Venator"
 	flag = F13VENATOR
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the Venator -- the Hunter. With your powerful rifle and your many years of experience, you are a formidable killing machine, capable of taking down even the most formidable targets. Note that you are not a rank-and-file legionary, and you should not be operating as such -- your job is special operations, not fighting alongside the hordes of the Legion."
 	supervisors = "the Centurion"
 	selection_color = "#ffdddd"
@@ -1259,8 +1259,8 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 /datum/job/CaesarsLegion/Legionnaire/f13slavemaster
 	title = "Legion Slavemaster"
 	flag = F13SLAVEMASTER
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the feared and respected disciplinary corps of the Legion. Acting as both master of the Slaves and de-facto executioner of the Centurion's will within his ranks, you are a faceless and undoubtedly cruel torturer... but be careful to not let your hubris and malice lead to a strikeback from those you thought broken."
 	supervisors = "the Decani and Centurion"
 	exp_requirements = 0

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -149,8 +149,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	title = "NCR Captain"
 	flag = F13CAPTAIN
 	head_announce = list("Security")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the commanding officer of your company and direct superior to the Veteran Ranger and Lieutenant. Coordinating with your staff, you must ensure that the objectives of High Command are completed to the letter. Working closely with your subordinates on logistics, mission planning and special operations with the Rangers, you are here to establish a strong foothold for the NCR within the region."
 	supervisors = "Colonel"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_CHANGE_IDS, ACCESS_NCRREP, ACCESS_NCR_COMMAND)
@@ -220,8 +220,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13lieutenant
 	title = "NCR Lieutenant"
 	flag = F13LIEUTENANT
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the direct superior to the NCOs and Enlisted, and under special circumstances, Rangers. You are the XO of Forward Camp Grassden. You plan patrols, training and missions, working in some cases with Rangers in accomplishing objectives otherwise beyond the capabilities of ordinary enlisted personnel, and conducting diplomacy with the region."
 	supervisors = "Captain"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_CHANGE_IDS, ACCESS_NCR_COMMAND)
@@ -288,8 +288,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13sergeant
 	title = "NCR Sergeant"
 	flag = F13SERGEANT
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the direct superior to the enlisted troops, working with the chain of command you echo the orders of your superiors and ensure that the enlisted follow them to the letter. Additionally, you are responsible for the wellbeing of the troops and their ongoing training with the NCR."
 	supervisors = "Lieutenant and Above"
 	selection_color = "#fff5cc"
@@ -373,8 +373,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13vetranger
 	title = "NCR Veteran Ranger"
 	flag = F13VETRANGER
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You answer directly to the Captain, working either independently or in a team to complete your mission objectives however required, operating either alone, in a squad or with the NCR Army. Your primary mission is to improve general opinion of the Republic, and conduct law enforcement as needed."
 	supervisors = "NCRA Captain, High Command"
 	selection_color = "#ffeeaa"
@@ -456,8 +456,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13ranger
 	title = "NCR Ranger"
 	flag = F13RANGER
-	total_positions = 3
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "As an NCR Ranger, you are the premier special forces unit of the NCR. You are the forward observations and support the Army in it's campaigns, as well as continuing the tradition of stopping slavery in it's tracks."
 	supervisors = "Veteran Ranger"
 	selection_color = "#fff5cc"
@@ -568,8 +568,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13heavytrooper
 	title = "NCR Heavy Trooper"
 	flag = F13HEAVYTROOPER
-	total_positions = 1
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the NCREG's heaviest hitter. Choose your loadout careful and ensure that you utilise your gear and armour to lay down suppressive fire, flush out enemies, and tank hits in the process."
 	supervisors = "Corporal and Above"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY)
@@ -647,8 +647,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13combatengineer
 	title = "NCR Combat Engineer"
 	flag = F13COMBATENGINEER
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are an enlisted trooper with an engineering skill set. You work closely with your squad, taking orders from the officers. You have the authority to command troopers if there are no non-commissioned officers present."
 	supervisors = "Corporals and Above"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY)
@@ -714,8 +714,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13combatmedic
 	title = "NCR Combat Medic"
 	flag = F13COMBATMEDIC
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a senior enlisted with a medical skill set. You work closely with your squad, taking orders from your officers. You have the authority to command troopers if there are no non-commissioned officers present."
 	supervisors = "Corporals and Above"
 	selection_color = "#fff5cc"
@@ -776,8 +776,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13corporal
 	title = "NCR Corporal"
 	flag = F13CORPORAL
-	total_positions = 2
-	spawn_positions = 3
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a junior NCO. You are expected to lead from the frontlines with your sergeant. Keep the troopers in order and keep your squad coherent."
 	supervisors = "Sergeant and above"
 	selection_color = "#fff5cc"
@@ -835,8 +835,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13trooper
 	title = "NCR Trooper"
 	flag = F13TROOPER
-	total_positions = 3
-	spawn_positions = 6
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are a trail expeditionary of the NCR Army, 13th Expeditionary Group. Obey your the NCOs and officers, no matter what you are expected to follow military discipline."
 	supervisors = "Corporals and Above"
 	selection_color = "#fff5cc"
@@ -896,8 +896,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13conscript
 	title = "NCR Conscript"
 	flag = F13CONSCRIPT
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the recent bulk of the NCR Army. You have been recently conscripted, given little to no training and were issued a gun. Obey your the NCOs and officers, no matter what you are expected to follow military discipline."
 	supervisors = "The Drill Sergeant, Corporals and Above"
 	selection_color = "#fff5cc"
@@ -957,8 +957,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	title = "NCR Representative"
 	flag = F13REP
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_NCRREP)
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are an influential representative for the NCR and experienced bureaucrat. You are here to further the objective and ensure the interests of the NCREG, your company or own enterprise are met through thick and thin, and have been supplied with ample amounts of money to do so. You likely have investments in the expeditionary initiative."
 	supervisors = "The Captain and the NCR"
 	display_order = JOB_DISPLAY_ORDER_REPRESENTATIVE
@@ -1025,8 +1025,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13medicalofficer
 	title = "NCR Medical Officer"
 	flag = F13MEDICALOFFICER
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the lead medical professional in Forward Camp Grassden, you do not have any command authority unless it is of medical nature. Your duties are to ensure your troopers are in good health and that medical supplies are stocked for troopers."
 	supervisors = "Captain and Above"
 	selection_color = "#fff5cc"
@@ -1072,8 +1072,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13logisticsofficer
 	title = "NCR Quartermaster"
 	flag = F13LOGISTICSOFFICER
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are the lead engineering professional in Forward Camp Grassden, you do not have any command authority beyond the logistical side. Your duties are to ensure your outpost is well defended, the armory is in order, and you always have supplies. Organize the rear echelon to offload the frontline officers and make things happen."
 	supervisors = "Captain and Above"
 	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY, ACCESS_NCR_COMMAND)
@@ -1127,8 +1127,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/job/ncr/f13rearechelon
 	title = "NCR Off-Duty"
 	flag = F13NCROFFDUTY
-	total_positions = 7
-	spawn_positions = 7
+	total_positions = 0
+	spawn_positions = 0
 	description = "You are off-duty NCR personnel in the Utah Region. Despite being out of uniform and off-duty you are still expected to follow NCR COMJ and represent the uniform properly. Failure to abide by this will result in disciplinary action."
 	supervisors = "All NCOs and COs"
 	enforces = "You may aid around the base with tasks such as clean up, fortification building, crop growing, or other non-combat related needs. You should not leave the base for any reason unless permitted by an on-duty Captain."

--- a/code/modules/jobs/job_types/raider.dm
+++ b/code/modules/jobs/job_types/raider.dm
@@ -19,8 +19,8 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	social_faction = FACTION_RAIDERS
 	exp_requirements = 600
 	exp_type = EXP_TYPE_FALLOUT
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 6
+	spawn_positions = 6
 	description = "You are a member of the underworld of the La Verkin region, well-established or a newcomer looking to rile things up. \
 	Morals and laws generally mean little to you. Perhaps you are a thief, chem dealer, deserter, or just a garden-variety murderer. \
 	The Den where you have spawned is a good hovel for scum like you, but take your troubles wherever you like. \
@@ -69,7 +69,7 @@ Within this file is the material to turn the previous odd-inclusion into a prope
 	name = "Raider"
 	jobtype = /datum/job/raider/f13raider
 	id = /obj/item/card/id/raider_tags
-	ears = null
+	ears = /obj/item/radio/headset/headset_den
 	belt = null
 	shoes = /obj/item/clothing/shoes/f13/raidertreads
 	uniform = /obj/item/clothing/under/f13/raider_leather

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -34,8 +34,8 @@
 	/datum/outfit/loadout/scavenger,
 	/datum/outfit/loadout/settler,
 	/datum/outfit/loadout/warrior,
-	/datum/outfit/loadout/ncrcitizen,
-	/datum/outfit/loadout/legioncivilian,
+	//datum/outfit/loadout/ncrcitizen,
+	//datum/outfit/loadout/legioncivilian,
 	/datum/outfit/loadout/wastelander_desert_ranger)
 
 /datum/outfit/job/wasteland/f13wastelander
@@ -43,7 +43,7 @@
 	jobtype = /datum/job/wasteland/f13wastelander
 
 	id = null
-	ears = null
+	ears = /obj/item/radio/headset
 	r_hand = /obj/item/book/granter/trait/selection
 	l_pocket = /obj/item/storage/bag/money/small/wastelander
 	r_pocket = /obj/item/flashlight/flare
@@ -68,6 +68,191 @@
 		/obj/item/clothing/suit/f13/veteran, \
 		/obj/item/clothing/suit/toggle/labcoat/f13/wanderer)
 
+
+/datum/job/wasteland/f13ncrscout
+	title = "NCR Scout"
+	flag = F13NCRSCOUT
+	faction = FACTION_WASTELAND
+	total_positions = -1
+	spawn_positions = -1
+	description = "You are an advance scout for the NCR, sent far afield to find areas that the NCR might have interest \
+	towards spreading democracy. You are a one man operation unless you encounter another NCR scout, with only your dog \
+	tags proving where your loyalty lies. Best to play nice with the locals so you can collect information and report back."
+	supervisors = "yourself"
+	selection_color = "#dddddd"
+
+	outfit = /datum/outfit/job/wasteland/f13ncrscout
+
+	access = list()		//we can expand on this and make alterations as people suggest different loadouts
+	minimal_access = list()
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/mentor = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+		/datum/matchmaking_pref/disciple = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+	)
+
+/datum/outfit/job/wasteland/f13ncrscout
+	name = "NCR Scout"
+	jobtype = /datum/job/wasteland/f13ncrscout
+
+	id = /obj/item/card/id/dogtag/town/ncr
+	ears = /obj/item/radio/headset/headset_ncr
+	uniform = /obj/item/clothing/under/f13/ncrcaravan
+	shoes = /obj/item/clothing/shoes/f13/tan
+	head = /obj/item/clothing/head/f13/cowboy
+	gloves = /obj/item/clothing/gloves/color/brown
+	l_hand = /obj/item/gun/ballistic/rifle/mag/varmint
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m556mm = 4,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/reagent_containers/pill/radx,
+		)
+
+
+/datum/job/wasteland/f13legion_explorer
+	title = "Legion Rimor"
+	flag = F13LEGIONRIMOR
+	faction = FACTION_WASTELAND
+	total_positions = -1
+	spawn_positions = -1
+	description = "You are a legion rimor, differed from a normal explorer by being given extra-autonomy as you explore far off \
+	locations looking for potential tribal recruits or locations bountiful for legion annexation. Unlike most of your brothers \
+	you are not as well trained nor as well equipped as a regular explorer, you must prove yourself as you make your way in this \
+	unfamiliar territory. Though you carry proof of being within the legion, experience has taught you to hide yourself."
+	supervisors = "yourself"
+	selection_color = "#dddddd"
+
+	outfit = /datum/outfit/job/wasteland/f13legion_explorer
+
+	access = list()		//we can expand on this and make alterations as people suggest different loadouts
+	minimal_access = list()
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/mentor = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+		/datum/matchmaking_pref/disciple = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+	)
+
+/datum/outfit/job/wasteland/f13legion_explorer
+	name = "Legion Rimor"
+	jobtype = /datum/job/wasteland/f13legion_explorer
+
+	id = /obj/item/card/id/dogtag/town/legion
+	ears = /obj/item/radio/headset/headset_legion
+	uniform = /obj/item/clothing/under/f13/doctor
+	shoes = /obj/item/clothing/shoes/f13/fancy
+	suit = /obj/item/clothing/suit/curator
+	head = /obj/item/clothing/head/scarecrow_hat
+	gloves = /obj/item/clothing/gloves/color/black
+	glasses = /obj/item/clothing/glasses/welding
+	l_hand = /obj/item/shield/riot/buckler
+	backpack_contents = list(
+		/obj/item/melee/onehanded/machete = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/reagent_containers/pill/radx,
+		)
+
+
+/datum/job/wasteland/f13brotherhood_initiate
+	title = "Brotherhood Scout-Knight"
+	flag = F13BOSSKNIGHT
+	faction = FACTION_WASTELAND
+	total_positions = -1
+	spawn_positions = -1
+	description = "As a scout-knight you are a member of the brotherhoods advanced recon, sparsely equipped and expected to \
+	survive and thrive in the wasteland. Your job is to detail advanced technologies, groups, and pre-war locations for \
+	other better equipped members in the brotherhood to sieze and bring back to the bunkers. Remember, you are so far out \
+	that you are practically alone, be prepared."
+	supervisors = "yourself"
+	selection_color = "#dddddd"
+
+	outfit = /datum/outfit/job/wasteland/f13brotherhood_initiate
+
+	access = list()		//we can expand on this and make alterations as people suggest different loadouts
+	minimal_access = list()
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/mentor = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+		/datum/matchmaking_pref/disciple = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+	)
+
+/datum/outfit/job/wasteland/f13brotherhood_initiate
+	name = "Brotherhood Scout-Knight"
+	jobtype = /datum/job/wasteland/f13brotherhood_initiate
+
+	id = /obj/item/card/id/dogtag/town/legion
+	ears = /obj/item/radio/headset/headset_bos
+	backpack = /obj/item/storage/backpack/explorer
+	suit = 			/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate
+	head = 			/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate
+	uniform =		/obj/item/clothing/under/syndicate/brotherhood
+	shoes = 		/obj/item/clothing/shoes/combat/swat
+	gloves = 		/obj/item/clothing/gloves/combat
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/wattz = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 3,
+		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/reagent_containers/pill/radx,
+		)
+
+
+/datum/job/wasteland/f13khan_runner
+	title = "Great Khan Runner"
+	flag = F13KHANRUNNER
+	faction = FACTION_WASTELAND
+	total_positions = -1
+	spawn_positions = -1
+	description = "You run chems for the great khans, either your tribe hates you or you're the best at surviving alone and \
+	unsupported. In either case, you have found yourself far out in this area looking to make and peddle chems so you can send \
+	caps back to your tribesman. Without your gang, you are at a huge disadvantage and your tribal tattoos are impossible to \
+	hide. Better make friends with the locals, maybe even the raiders."
+	supervisors = "yourself"
+	selection_color = "#dddddd"
+
+	outfit = /datum/outfit/job/wasteland/f13khan_runner
+
+	access = list()		//we can expand on this and make alterations as people suggest different loadouts
+	minimal_access = list()
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/mentor = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+		/datum/matchmaking_pref/disciple = list(
+			/datum/job/wasteland/f13wastelander,
+		),
+	)
+
+/datum/outfit/job/wasteland/f13khan_runner
+	name = "Great Khan Runner"
+	jobtype = /datum/job/wasteland/f13khan_runner
+
+	id = /obj/item/card/id/khantattoo
+	ears = /obj/item/radio/headset/headset_khans
+	shoes = /obj/item/clothing/shoes/f13/military/khan
+	backpack =	/obj/item/storage/backpack/satchel/explorer
+	satchel = 	/obj/item/storage/backpack/satchel/old
+	uniform = /obj/item/clothing/under/f13/khan
+	gloves = /obj/item/melee/unarmed/brass/spiked
+	box = /obj/item/storage/survivalkit/khan
+	backpack_contents = list(
+		/obj/item/twohanded/baseball/spiked = 1,
+		/obj/item/storage/bag/money/small/khan = 1,
+		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/reagent_containers/pill/radx
+		)
+
+
+///////////////////////////////// Loadouts ///////////////////////////////////////////////////
 /datum/outfit/loadout/salvager
 	name = "Salvager"
 	uniform = /obj/item/clothing/under/f13/machinist

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -229,6 +229,10 @@ GLOBAL_LIST_INIT(vault_positions, list(
 GLOBAL_LIST_INIT(wasteland_positions, list(
 	"Vigilante",
 	"Wastelander",
+	"NCR Scout",
+	"Legion Rimor",
+	"Brotherhood Scout-Knight",
+	"Great Khan Runner",
 	"Raider",
 	"Tribal",
 ))
@@ -271,11 +275,11 @@ GLOBAL_LIST_INIT(followers_positions, list(
 GLOBAL_LIST_INIT(position_categories, list(
 	EXP_TYPE_WASTELAND = list("jobs" = wasteland_positions, "color" = "#5a5a5a"),
 	EXP_TYPE_BIGHORN = list("jobs" = bighorn_positions, "color" = "#d7b088"),
-	EXP_TYPE_NCR = list("jobs" = ncr_positions, "color" = "#ffeeaa"),
+	//EXP_TYPE_NCR = list("jobs" = ncr_positions, "color" = "#ffeeaa"),
 	EXP_TYPE_FOLLOWERS = list("jobs" = followers_positions, "color" = "#ffeeaa"),
-	EXP_TYPE_LEGION = list("jobs" = legion_positions, "color" = "#f81717"),
-	EXP_TYPE_KHAN = list("jobs" = khan_positions, "color" = "#006666"),
-	EXP_TYPE_BROTHERHOOD = list("jobs" = brotherhood_positions, "color" = "#95a5a6"),
+	//EXP_TYPE_LEGION = list("jobs" = legion_positions, "color" = "#f81717"),
+	//EXP_TYPE_KHAN = list("jobs" = khan_positions, "color" = "#006666"),
+	//EXP_TYPE_BROTHERHOOD = list("jobs" = brotherhood_positions, "color" = "#95a5a6"),
 	EXP_TYPE_ENCLAVE = list("jobs" = enclave_positions, "color" = "#5a5bc7"),
 ))
 


### PR DESCRIPTION
-Removed brotherhood, legion, khan, and NCR as faction options. 
-Added 4 new jobs as scouts connected to these factions. Each job has its factions headset and ID tag, allowing them to identify themselves. They are very lightly equipped for their factions and in the case of rimor wearing a disguise. 
-Renamed the den headset to raider and gave said headset to the raiders. 
-Wastelanders now spawn with headsets.
-Added landmark spawners for the new scout jobs.
-Renamed some follower clothing to westford medical. -Changed some displays to use proper names.

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
