### PR TITLE
Hotfixes

### DIFF
--- a/code/modules/clothing/ears/_ears.dm
+++ b/code/modules/clothing/ears/_ears.dm
@@ -7,6 +7,7 @@
 	slot_flags = ITEM_SLOT_EARS
 	resistance_flags = NONE
 	custom_price = PRICE_BELOW_NORMAL
+	raider_armor = TRUE
 
 /obj/item/clothing/ears/earmuffs
 	name = "earmuffs"

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -5,6 +5,7 @@
 	slot_flags = ITEM_SLOT_MASK
 	strip_delay = 40
 	equip_delay_other = 40
+	raider_armor = TRUE
 	var/modifies_speech = FALSE
 	var/mask_adjusted = 0
 	var/adjusted_flags = null

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -5,6 +5,7 @@
 	slot_flags = ITEM_SLOT_NECK
 	strip_delay = 40
 	equip_delay_other = 40
+	raider_armor = TRUE
 
 /obj/item/clothing/neck/worn_overlays(isinhands = FALSE, icon_file, used_state, style_flags = NONE)
 	. = ..()

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -51,9 +51,8 @@
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	backpack_contents = list(
-		/obj/item/reagent_containers/hypospray/medipen/stimpak,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak,
-		/obj/item/reagent_containers/pill/radx,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
+		/obj/item/reagent_containers/pill/radx = 1
 		)
 
 /datum/outfit/job/wasteland/f13wastelander/pre_equip(mob/living/carbon/human/H)
@@ -108,7 +107,7 @@
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556mm = 4,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/reagent_containers/pill/radx,
+		/obj/item/reagent_containers/pill/radx = 1
 		)
 
 
@@ -153,8 +152,8 @@
 	l_hand = /obj/item/shield/riot/buckler
 	backpack_contents = list(
 		/obj/item/melee/onehanded/machete = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/reagent_containers/pill/radx,
+		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
+		/obj/item/reagent_containers/pill/patch/hydra = 1
 		)
 
 
@@ -201,7 +200,7 @@
 		/obj/item/stock_parts/cell/ammo/ec = 3,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/reagent_containers/pill/radx,
+		/obj/item/reagent_containers/pill/radx = 1
 		)
 
 
@@ -248,7 +247,7 @@
 		/obj/item/storage/bag/money/small/khan = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
-		/obj/item/reagent_containers/pill/radx
+		/obj/item/reagent_containers/pill/radx = 1
 		)
 
 


### PR DESCRIPTION
-Legion Rimor now has 2 healing powder and 1 hydra instead of stimpaks and rad-x 
-Radx pills should now spawn properly for all wasteland jobs if they hadn't before. 
-Raiders can now freely equip neck, mask, and ear slot items without restriction, meaning they can smoke again.

