### PR TITLE
Scout Upgrades + Item desc fixes

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -315,6 +315,12 @@
 #define TRAIT_TRIBAL_BONEDANCER			"bone dancer"
 #define TRAIT_TRIBAL_ALL				"tribal all"
 
+// Faction Teaching Perks, mainly for scouts, but let people upgrade into faction drip.
+#define TRAIT_FORMER_LEGION			"former_legion"
+#define TRAIT_FORMER_NCR			"former_ncr"
+#define TRAIT_FORMER_BROTHERHOOD	"former_brotherhood"
+#define TRAIT_FORMER_KHAN			"former_khan"
+#define TRAIT_FORMER_FOLLOWER		"former_follower" // Technically for the clinic itself
 
 //non-mob traits
 #define TRAIT_PARALYSIS				"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -18,11 +18,13 @@
 	name = "NCR Patrol Belt"
 	result = /obj/item/storage/belt/military/assault/ncr
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/belt/legion
 	name = "Legionary Marching Belt"
 	result = /obj/item/storage/belt/military/assault/legion
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_LEGION
 
 /datum/crafting_recipe/belt/enclave
 	name = "Old Army Belt (Enclave)"
@@ -85,6 +87,7 @@
 		/obj/item/toy/crayon/spraycan,
 	)
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/belt/holster/ranger/legion
 	name = "Ranger-Hunter Cape"
@@ -94,6 +97,7 @@
 		/obj/item/toy/crayon/spraycan,
 	)
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_LEGION
 
 /datum/crafting_recipe/belt/bandolier
 	name = "Shotgun Bandolier"

--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -270,6 +270,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_MELEE
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_KHAN
 
 
 // LEGION SPECIFIC

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -191,6 +191,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/ncrsalvagedhelmetconversion
 	name = "NCR salvaged power armor helmet"
@@ -207,6 +208,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/boscombatarmor
 	name = "knight armor"
@@ -228,6 +230,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_BROTHERHOOD
 
 /datum/crafting_recipe/boscombathelmet
 	name = "knight helmet"
@@ -249,6 +252,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_BROTHERHOOD
 
 /datum/crafting_recipe/boscombatarmormk2
 	name = "reinforced knight armor"
@@ -268,6 +272,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_BROTHERHOOD
 
 /datum/crafting_recipe/boscombathelmetmk2
 	name = "reinforced knight helmet"
@@ -287,6 +292,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_BROTHERHOOD
 
 /datum/crafting_recipe/durathread_vest
 	name = "Makeshift Durathread Armour"
@@ -508,6 +514,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_KHAN
 
 /datum/crafting_recipe/ncrsturdy
 	name = "NCR Sturdy Boots"
@@ -519,6 +526,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 //Gauntlets
 
@@ -542,6 +550,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_KHAN
 
 
 /*CRAFT rework: removed for balance
@@ -625,6 +634,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/tailor/legionuniform
 	name = "Legion Uniform"
@@ -635,6 +645,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_LEGION
 
 /datum/crafting_recipe/settler
 	name = "Settler outfit"
@@ -1098,6 +1109,7 @@
 	time = 50
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/durathread_helmet
 	name = "Makeshift Helmet"
 	result = /obj/item/clothing/head/helmet/durathread
@@ -1106,6 +1118,7 @@
 	time = 40
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/fannypack
 	name = "Fannypack"
 	result = /obj/item/storage/belt/fannypack
@@ -1114,6 +1127,7 @@
 	time = 20
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 //f13 additions
 /datum/crafting_recipe/metalarmor
 	name = "metal armor"
@@ -1125,6 +1139,7 @@
 	time = 120
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/Imetalarmor
 	name = "improved metal armor"
 	result = /obj/item/clothing/suit/armor/f13/ibmetalarmor
@@ -1136,6 +1151,7 @@
 	time = 120
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/IImetalarmor
 	name = "upgrading metal armor"
 	result = /obj/item/clothing/suit/armor/f13/ibmetalarmor
@@ -1146,6 +1162,7 @@
 	time = 120
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 //Tribal armors
 /datum/crafting_recipe/tribalgeckoarmor
 	name = "Gecko Armor"
@@ -1169,6 +1186,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/supafly_reinforced
 	name = "reinforced supafly armor"
 	result = /obj/item/clothing/suit/armor/f13/raider/r/supafly
@@ -1179,6 +1197,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/yankeehelm_reinforced
 	name = "reinforced yankee helmet"
 	result = /obj/item/clothing/head/helmet/f13/raider/r/yankee/
@@ -1189,6 +1208,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/yankee_reinforced
 	name = "reinforced yankee armor"
 	result = /obj/item/clothing/suit/armor/f13/raider/r/yankee
@@ -1199,6 +1219,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/blasterhelm_reinforced
 	name = "reinforced blaster helmet"
 	result = /obj/item/clothing/head/helmet/f13/raider/r/blastmaster
@@ -1209,6 +1230,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/blaster_reinforced
 	name = "reinforced blaster armor"
 	result = /obj/item/clothing/suit/armor/f13/raider/r/blastmaster
@@ -1219,6 +1241,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/sadisthelm_reinforced
 	name = "reinforced sadist helmet"
 	result = /obj/item/clothing/head/helmet/f13/raider/r/arclight
@@ -1229,6 +1252,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/sadist_reinforced
 	name = "reinforced sadist armor"
 	result = /obj/item/clothing/suit/armor/f13/raider/r/sadist
@@ -1239,6 +1263,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/fiendshelm_reinforced
 	name = "reinforced fiend helmet"
 	result = /obj/item/clothing/head/helmet/f13/fiend_reinforced
@@ -1249,6 +1274,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/badlands_reinforced
 	name = "reinforced badlands armor"
 	result = /obj/item/clothing/suit/armor/f13/raider/r/badlands
@@ -1259,6 +1285,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/painspikehelm_reinforced
 	name = "reinforced painspike helmet"
 	result = /obj/item/clothing/head/helmet/f13/raider/r/psychotic
@@ -1269,6 +1296,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/painspike_reinforced
 	name = "reinforced painspike armor"
 	result = /obj/item/clothing/suit/armor/f13/raider/r/painspike
@@ -1279,6 +1307,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/iconoclast_reinforced
 	name = "reinforced iconoclast armor"
 	result = /obj/item/clothing/suit/armor/f13/raider/r/iconoclast
@@ -1289,6 +1318,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/ncrexile_reinforced
 	name = "reinforced NCR deserter armor"
 	result = /obj/item/clothing/suit/armor/f13/exile/r/ncr
@@ -1299,6 +1329,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/legion_reinforced
 	name = "reinforced punished Legion armor"
 	result = /obj/item/clothing/suit/armor/f13/exile/r/legion
@@ -1309,6 +1340,7 @@
 	time = 60
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
+
 /datum/crafting_recipe/bos_reinforced
 	name = "reinforced BoS exile armor"
 	result = /obj/item/clothing/suit/armor/f13/exile/r/bos
@@ -1338,6 +1370,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_LEGION
 
 /datum/crafting_recipe/legioncombathelmet
 	name = "Legion combat helmet"
@@ -1357,6 +1390,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_LEGION
 
 /datum/crafting_recipe/legioncombatarmormk2
 	name = "reinforced Legion combat armor"
@@ -1372,6 +1406,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_LEGION
 
 /datum/crafting_recipe/legioncombathelmetmk2
 	name = "reinforced Legion combat helmet"
@@ -1387,6 +1422,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_LEGION
 
 // NCR Armor conversions
 /datum/crafting_recipe/ncrcombatarmor
@@ -1406,6 +1442,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/ncrcombathelmet
 	name = "NCR combat helmet"
@@ -1425,6 +1462,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/ncrcombatarmormk2
 	name = "reinforced NCR combat armor"
@@ -1440,6 +1478,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
 
 /datum/crafting_recipe/ncrcombathelmetmk2
 	name = "reinforced NCR combat helmet"
@@ -1455,11 +1494,60 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_NCR
+
+
+
+// Khan Armor conversions
+/datum/crafting_recipe/khanjacket
+	name = "Khan jacket"
+	result = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
+	reqs = list(
+		/obj/item/clothing/suit/armor/f13/leather_jacket/combat = 1,
+		/obj/item/toy/crayon/spraycan,
+	)
+	time = 30
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+	always_available = FALSE
+	granting_trait = TRAIT_FORMER_KHAN
+
+/datum/crafting_recipe/khanjacket_armored
+	name = "Khan armored jacket"
+	result = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/armored
+	reqs = list(
+		/obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket = 1,
+		/obj/item/stack/sheet/cloth = 1,
+		/obj/item/stack/crafting/armor_plate = 2,
+		/obj/item/stack/crafting/metalparts = 5,
+		/obj/item/stack/crafting/goodparts = 2
+	)
+	time = 30
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+	always_available = FALSE
+	granting_trait = TRAIT_FORMER_KHAN
+
+/datum/crafting_recipe/khanjacket_battle
+	name = "Khan battle coat"
+	result = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	reqs = list(
+		/obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/armored = 1,
+		/obj/item/stack/sheet/cloth = 5,
+		/obj/item/stack/crafting/armor_plate = 4,
+		/obj/item/stack/crafting/metalparts = 3,
+		/obj/item/stack/crafting/goodparts = 1
+	)
+	time = 30
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+	always_available = FALSE
+	granting_trait = TRAIT_FORMER_KHAN
+
 
 //Follower Armor
-
 /datum/crafting_recipe/follower_light
-	name = "Follower Insignia Stitching"
+	name = "Clinic Insignia Stitching"
 	result = /obj/item/clothing/suit/hooded/followerlight
 	reqs = list(/obj/item/clothing/suit/toggle/labcoat = 1,
 				/obj/item/stack/sheet/cloth = 1)
@@ -1468,9 +1556,10 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_FOLLOWER
 
 /datum/crafting_recipe/follower_medium
-	name = "Follower Labcoat Plating"
+	name = "Clinic Labcoat Plating"
 	result = /obj/item/clothing/suit/hooded/followermedium
 	reqs = list(/obj/item/clothing/suit/hooded/followerlight = 1,
 				/obj/item/stack/sheet/cloth = 1,
@@ -1482,9 +1571,10 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_FOLLOWER
 
 /datum/crafting_recipe/follower_heavy
-	name = "Follower Labcoat Reforging"
+	name = "Clinic Labcoat Reforging"
 	result = /obj/item/clothing/suit/hooded/followerheavy
 	reqs = list(/obj/item/clothing/suit/hooded/followermedium = 1,
 				/obj/item/stack/sheet/cloth = 1,
@@ -1496,3 +1586,4 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 	always_available = FALSE
+	granting_trait = TRAIT_FORMER_FOLLOWER

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -946,8 +946,8 @@
 //Town
 
 /obj/item/clothing/suit/armor/f13/combat/dusty
-	name = "Dusty Trails combat armor"
-	desc = "An old military grade pre war combat armor, repainted to the colour scheme of the Dusty Trails Caravan Company."
+	name = "\improper Westford combat armor"
+	desc = "An old military grade pre war combat armor, repainted to the colour scheme of Westford."
 	icon = 'icons/fallout/clothing/armored_medium.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/suit.dmi'
 	icon_state = "combat_armor_dusty"
@@ -955,8 +955,8 @@
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 10, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 25, "acid" = 0, "wound" = 25)
 
 /obj/item/clothing/suit/armor/f13/combat/mk2/dusty
-	name = "reinforced Dusty Trails combat armor"
-	desc = "A reinforced set of bracers, greaves, and torso plating of prewar design. This one is kitted with additional plates, repainted to the colour scheme of the Dusty Trails Caravan Company."
+	name = "\improper Westford reinforced combat armor"
+	desc = "A reinforced set of bracers, greaves, and torso plating of prewar design. This one is kitted with additional plates, repainted to the colour scheme of Westford."
 	icon = 'icons/fallout/clothing/armored_medium.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/suit.dmi'
 	icon_state = "combat_armor_dusty_mk2"
@@ -964,8 +964,8 @@
 	mutantrace_variation = NONE
 
 /obj/item/clothing/suit/armor/f13/usmcriot/dusty
-	name = "Dusty Trails riot armor"
-	desc = "A custom suit of armor owned by a mercenary Lieutenant, in the colors of the Dusty Trails Caravan Company."
+	name = "\improper Westford riot armor"
+	desc = "A custom suit of armor used by the sheriff, in the colors of Westford."
 	icon = 'icons/fallout/clothing/armored_medium.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/suit.dmi'
 	icon_state = "dusty_lieutenant"

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -531,6 +531,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 35, "energy" = 20, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 0, "wound" = 10)
+	damage_threshold = STYLE_DIGITIGRADE
 
 /obj/item/clothing/head/hooded/cloakhood/shunter
 	name = "Quickclaw hood"
@@ -563,7 +564,7 @@
 	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 20, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 80, "wound" = 10)
 
 /obj/item/clothing/suit/hooded/followermedium
-	name = "\improper Followers plated labcoat"
+	name = "\improper Clinic plated labcoat"
 	desc = "A modified labcoat fitted with flexible plates under the surface for the doctor who might find himself privy to the dangers of the wasteland."
 	icon = 'icons/fallout/clothing/suits_cosmetic.dmi'
 	hoodtype = /obj/item/clothing/head/hooded/followermedium
@@ -575,7 +576,7 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small
 
 /obj/item/clothing/head/hooded/followermedium
-	name = "\improper Followers plated labcoat hood"
+	name = "\improper Clinic plated labcoat hood"
 	icon_state = "follower_medium"
 	icon = 'icons/fallout/clothing/hats.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'
@@ -584,7 +585,7 @@
 	armor = list("melee" = 30, "bullet" = 40, "laser" = 25, "energy" = 25, "bomb" = 20, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 80, "wound" = 20)
 
 /obj/item/clothing/suit/hooded/followerheavy
-	name = "\improper Followers guard heavy armor"
+	name = "\improper Clinic guard heavy armor"
 	desc = "An overhauled set of armor using a mixture of treated metal plates and restitched labcoat material, built to protect those who cannot protect themselves."
 	icon = 'icons/fallout/clothing/suits_cosmetic.dmi'
 	hoodtype = /obj/item/clothing/head/hooded/followerheavy
@@ -600,7 +601,7 @@
 	AddComponent(/datum/component/armor_plate/weak)
 
 /obj/item/clothing/head/hooded/followerheavy
-	name = "\improper Followers guard heavy armor hood"
+	name = "\improper Clinic guard heavy armor hood"
 	icon_state = "follower_heavy"
 	icon = 'icons/fallout/clothing/hats.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/head.dmi'

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -110,6 +110,12 @@
 		/obj/item/reagent_containers/pill/radx = 1
 		)
 
+/datum/outfit/job/wasteland/f13ncrscout/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+
+	ADD_TRAIT(H, TRAIT_FORMER_NCR,  REF(src))
 
 /datum/job/wasteland/f13legion_explorer
 	title = "Legion Rimor"
@@ -156,6 +162,13 @@
 		/obj/item/reagent_containers/pill/patch/hydra = 1
 		)
 
+/datum/outfit/job/wasteland/f13legion_explorer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+
+	ADD_TRAIT(H, TRAIT_MARS_TEACH,  REF(src))
+	ADD_TRAIT(H, TRAIT_FORMER_LEGION,  REF(src))
 
 /datum/job/wasteland/f13brotherhood_initiate
 	title = "Brotherhood Scout-Knight"
@@ -203,6 +216,13 @@
 		/obj/item/reagent_containers/pill/radx = 1
 		)
 
+/datum/outfit/job/wasteland/f13brotherhood_initiate/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+
+	ADD_TRAIT(H, TRAIT_FORMER_BROTHERHOOD,  REF(src))
+
 
 /datum/job/wasteland/f13khan_runner
 	title = "Great Khan Runner"
@@ -249,6 +269,13 @@
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/reagent_containers/pill/radx = 1
 		)
+
+/datum/outfit/job/wasteland/f13khan_runner/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+
+	ADD_TRAIT(H, TRAIT_FORMER_KHAN,  REF(src))
 
 
 ///////////////////////////////// Loadouts ///////////////////////////////////////////////////


### PR DESCRIPTION
-Fixed some descriptions for clinic and police armor that referenced followers and DT.
-Scouts can now craft faction armor conversions and some faction specific items/clothing. Mainly combat armor conversions save for khans, who instead can craft their jackets, armored coats, and battle coats.
-Legion scouts also gain Mars Teachings for additional faction specific skills.
-Clinic doctors and admins can now craft the light, medium, and heavy armor labcoats.

Didn't test any of this but I'd be surprised if it had an issue given it compiled. All small changes.

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [X] You documented all of your changes.
